### PR TITLE
Create futuristic Studio VBG experience with multi-page dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "sonner": "^1.7.4",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
+        "uuid": "^13.0.0",
         "vaul": "^0.9.9",
         "zod": "^3.25.76"
       },
@@ -6519,6 +6520,19 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
     },
     "node_modules/vaul": {
       "version": "0.9.9",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "sonner": "^1.7.4",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
+    "uuid": "^13.0.0",
     "vaul": "^0.9.9",
     "zod": "^3.25.76"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,17 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import Services from "./pages/Services";
+import ServiceDetail from "./pages/ServiceDetail";
+import Playground from "./pages/Playground";
+import Portfolio from "./pages/Portfolio";
+import Process from "./pages/Process";
+import QuoteBuilder from "./pages/QuoteBuilder";
+import Auth from "./pages/Auth";
+import Dashboard from "./pages/Dashboard";
+import { StudioProvider } from "./context/StudioContext";
+import { WaveMenu } from "./components/WaveMenu";
+import { ProtectedRoute } from "./components/ProtectedRoute";
 
 const queryClient = new QueryClient();
 
@@ -13,13 +24,31 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Index />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
+      <StudioProvider>
+        <BrowserRouter>
+          <WaveMenu />
+          <Routes>
+            <Route path="/" element={<Index />} />
+            <Route path="/services" element={<Services />} />
+            <Route path="/services/:slug" element={<ServiceDetail />} />
+            <Route path="/playground" element={<Playground />} />
+            <Route path="/portfolio" element={<Portfolio />} />
+            <Route path="/process" element={<Process />} />
+            <Route path="/quote" element={<QuoteBuilder />} />
+            <Route path="/auth" element={<Auth />} />
+            <Route
+              path="/dashboard"
+              element={(
+                <ProtectedRoute>
+                  <Dashboard />
+                </ProtectedRoute>
+              )}
+            />
+            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </BrowserRouter>
+      </StudioProvider>
     </TooltipProvider>
   </QueryClientProvider>
 );

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,14 @@
+import { ReactNode } from "react";
+import { Navigate, useLocation } from "react-router-dom";
+import { useStudio } from "@/context/StudioContext";
+
+export const ProtectedRoute = ({ children }: { children: ReactNode }) => {
+  const { user } = useStudio();
+  const location = useLocation();
+
+  if (!user) {
+    return <Navigate to="/auth" state={{ from: location.pathname }} replace />;
+  }
+
+  return <>{children}</>;
+};

--- a/src/components/WaveMenu.tsx
+++ b/src/components/WaveMenu.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import { Link, useLocation } from "react-router-dom";
+import { navigationItems } from "@/lib/navigation";
+import { cn } from "@/lib/utils";
+
+export const WaveMenu = () => {
+  const [expanded, setExpanded] = useState(true);
+  const location = useLocation();
+
+  return (
+    <div className="pointer-events-none fixed right-2 top-0 z-50 hidden h-screen lg:flex">
+      <div className="pointer-events-auto flex h-full flex-col justify-center gap-4">
+        <button
+          type="button"
+          onClick={() => setExpanded((prev) => !prev)}
+          className="group relative overflow-hidden rounded-full border border-white/20 bg-slate-900/60 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white shadow-[0_0_30px_rgba(0,0,0,0.5)] backdrop-blur transition hover:bg-slate-900/80"
+        >
+          <span className="relative inline-flex items-center gap-2">
+            <span className="h-2 w-2 rounded-full bg-emerald-400 shadow-[0_0_10px_rgba(16,185,129,0.8)]" />
+            {expanded ? "Mode vague" : "Menu"}
+          </span>
+          <span className="absolute inset-0 animate-[pulse_2s_infinite] bg-gradient-to-r from-emerald-400/40 via-transparent to-cyan-500/40 opacity-0 transition group-hover:opacity-100" />
+        </button>
+        <nav
+          aria-label="Menu nébuleux"
+          className={cn(
+            "relative flex w-72 origin-right flex-col gap-3 rounded-l-3xl border border-white/10 bg-gradient-to-b from-slate-950/80 via-slate-900/70 to-slate-950/80 p-4 text-sm text-white shadow-[0_0_60px_rgba(14,165,233,0.35)] transition-all duration-700",
+            expanded ? "translate-x-0 opacity-100" : "translate-x-28 opacity-0"
+          )}
+        >
+          <div className="pointer-events-none absolute -right-[60px] top-0 h-full w-[120px] overflow-hidden">
+            <div className="absolute inset-0 bg-[radial-gradient(circle_at_30%_50%,rgba(14,165,233,0.7),transparent_60%)] blur-3xl" />
+          </div>
+          {navigationItems.map((item) => {
+            const active = location.pathname === item.to || location.pathname.startsWith(`${item.to}/`);
+            return (
+              <Link
+                key={item.to}
+                to={item.to}
+                className={cn(
+                  "group relative flex items-center justify-between overflow-hidden rounded-2xl border border-white/10 px-4 py-3 transition-all",
+                  "hover:border-cyan-400/80 hover:bg-white/10 hover:text-white",
+                  active ? "border-cyan-300 bg-white/20 text-white shadow-[0_0_30px_rgba(34,211,238,0.45)]" : "text-slate-200"
+                )}
+              >
+                <div className="flex items-center gap-3">
+                  <span className="text-xl">{item.emoji}</span>
+                  <div>
+                    <p className="text-base font-semibold uppercase tracking-[0.2em]">{item.label}</p>
+                    <p className="text-[0.7rem] text-slate-300/80">{item.tooltip}</p>
+                  </div>
+                </div>
+                <span className="text-xs font-mono text-cyan-300">{active ? "ON" : ".."}</span>
+                <span className="absolute inset-0 -z-10 translate-x-[-80%] bg-[radial-gradient(circle_at_right,rgba(6,182,212,0.45),transparent_60%)] transition-transform duration-700 group-hover:translate-x-0" />
+              </Link>
+            );
+          })}
+        </nav>
+      </div>
+    </div>
+  );
+};

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => {
   return (

--- a/src/context/StudioContext.tsx
+++ b/src/context/StudioContext.tsx
@@ -1,0 +1,416 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, useState, type ReactNode } from "react";
+import { v4 as uuid } from "uuid";
+
+// Local helper to generate shimmering gradient placeholders
+const gradientPool = [
+  "from-[#61f4de] via-[#2471d6] to-[#290a5c]",
+  "from-[#fd7bff] via-[#4d31ff] to-[#120248]",
+  "from-[#ffdc63] via-[#ff7a18] to-[#45108a]",
+  "from-[#5dff9d] via-[#19b6ff] to-[#5916e1]",
+  "from-[#ff9cc6] via-[#ff6c6c] to-[#2f2aa0]",
+];
+
+export type PortfolioItem = {
+  id: string;
+  title: string;
+  tagline: string;
+  category: string;
+  year: number;
+  duration: string;
+  description: string;
+  thumbnail: string;
+  gradient: string;
+  aiTools: string[];
+  deliverables: string[];
+  socialStack: string[];
+};
+
+export type PricingTier = {
+  id: string;
+  name: string;
+  price: number;
+  description: string;
+  deliverables: string[];
+  sla: string;
+};
+
+export type QuoteRequest = {
+  id: string;
+  clientId: string;
+  clientName: string;
+  projectName: string;
+  budgetRange: string;
+  deadline: string;
+  services: string[];
+  status: "nouveau" | "en revue" | "validé" | "refusé";
+  moodboardPrompt: string;
+  createdAt: string;
+};
+
+export type ChatMessage = {
+  id: string;
+  from: "studio" | "client";
+  content: string;
+  timestamp: string;
+};
+
+export type ChatThread = {
+  quoteId: string;
+  clientName: string;
+  projectName: string;
+  messages: ChatMessage[];
+};
+
+export type ContactRequest = {
+  id: string;
+  name: string;
+  email: string;
+  projectSpark: string;
+  urgency: "hier" | "cette-semaine" | "quand-c-est-parfait";
+  createdAt: string;
+};
+
+export type ClientAccount = {
+  id: string;
+  name: string;
+  email: string;
+  password: string;
+  company: string;
+  industry: string;
+  membership: "Impulse" | "Hyperdrive" | "Continuum";
+  avatarHue: number;
+  lastProject?: string;
+};
+
+type StudioContextValue = {
+  user: ClientAccount | null;
+  clients: ClientAccount[];
+  portfolioItems: PortfolioItem[];
+  pricingTiers: PricingTier[];
+  quoteRequests: QuoteRequest[];
+  contactRequests: ContactRequest[];
+  chats: ChatThread[];
+  register: (payload: Omit<ClientAccount, "id" | "avatarHue">) => { success: boolean; message?: string };
+  login: (email: string, password: string) => { success: boolean; message?: string };
+  logout: () => void;
+  addPortfolioItem: (payload: Omit<PortfolioItem, "id" | "gradient"> & { gradient?: string }) => void;
+  updatePortfolioItem: (id: string, updates: Partial<PortfolioItem>) => void;
+  removePortfolioItem: (id: string) => void;
+  updatePricingTier: (id: string, updates: Partial<PricingTier>) => void;
+  createQuoteRequest: (payload: Omit<QuoteRequest, "id" | "status" | "createdAt" | "clientId" | "clientName">) => QuoteRequest | null;
+  advanceQuoteStatus: (id: string, status: QuoteRequest["status"]) => void;
+  appendChatMessage: (quoteId: string, message: Omit<ChatMessage, "id" | "timestamp">) => void;
+  recordContactRequest: (payload: Omit<ContactRequest, "id" | "createdAt">) => void;
+};
+
+const StudioContext = createContext<StudioContextValue | undefined>(undefined);
+
+const initialPortfolio: PortfolioItem[] = [
+  {
+    id: uuid(),
+    title: "Sillage Quantique pour OuraSense",
+    tagline: "Une chorégraphie de particules pour lancer un wearable de demain",
+    category: "Lancement produit",
+    year: 2025,
+    duration: "01:12",
+    description:
+      "Campagne hybride live-action x IA générative mixant captations volumétriques, danse kinétique et set virtuel sous Kling 2.5. Déploiement 360° en 48h sur TikTok, YT Shorts et DOOH holographiques.",
+    thumbnail:
+      "https://images.unsplash.com/photo-1661961110671-75fd3f52d44c?q=80&w=1200",
+    gradient: gradientPool[0],
+    aiTools: ["Kling 2.5", "Seedance Pro", "Midjourney V7"],
+    deliverables: ["Hero film", "9 déclinaisons sociales", "Toolkit AR"],
+    socialStack: ["TikTok Pulse", "YouTube Shorts", "Volumetric DOOH"],
+  },
+  {
+    id: uuid(),
+    title: "Campagne Hyperlapse pour Luma Skies",
+    tagline: "Un voyage comique dans un cloud gaming atmosphérique",
+    category: "Brand content",
+    year: 2025,
+    duration: "02:04",
+    description:
+      "Direction artistique futuriste mêlant props tangibles et matte painting génératif. Mixage spatial Suno AI + sound design analogique pour un rendu flamboyant.",
+    thumbnail:
+      "https://images.unsplash.com/photo-1640622650674-6d8c98f8e909?q=80&w=1200",
+    gradient: gradientPool[1],
+    aiTools: ["Midjourney V7", "Veo 3", "Suno AI"],
+    deliverables: ["Film manifesto", "Bumpers Twitch", "Loop Spotify Canvas"],
+    socialStack: ["Instagram Reels", "Twitch", "Spotify Canvas"],
+  },
+  {
+    id: uuid(),
+    title: "XR Comedy Roast pour Qonto Quantum",
+    tagline: "La finance qui se moque d'elle-même en réalité mixte",
+    category: "Event hybride",
+    year: 2024,
+    duration: "00:58",
+    description:
+      "Plateau XR avec avatars lip-sync LypSync V2 et scénar impro générée par GPT-Vizz. Live multi-cam Davinci Resolve + macros Atem Scriptées.",
+    thumbnail:
+      "https://images.unsplash.com/photo-1529257414771-1960a42fd38f?q=80&w=1200",
+    gradient: gradientPool[2],
+    aiTools: ["LypSync V2", "Seedance Pro", "DaVinci Resolve"],
+    deliverables: ["Live replay", "Clips snackable", "Pack memes internes"],
+    socialStack: ["LinkedIn", "YouTube Live", "Internal Workplace"],
+  },
+];
+
+const initialPricing: PricingTier[] = [
+  {
+    id: uuid(),
+    name: "Impulse",
+    price: 4200,
+    description: "Pour les start-up qui veulent frapper fort en moins de 10 jours",
+    deliverables: ["Sprint créatif IA", "Shoot studio 4h", "Kit social 6 formats"],
+    sla: "Delivery express 4K en 72h",
+  },
+  {
+    id: uuid(),
+    name: "Hyperdrive",
+    price: 9700,
+    description: "Campagne multi-canal chorégraphiée par notre pipeline intelligent",
+    deliverables: ["Storyboard Midjourney V7", "Tournage bi-cam", "Montage Davinci + VFX Veo 3"],
+    sla: "Pilotage complet sur 21 jours",
+  },
+  {
+    id: uuid(),
+    name: "Continuum",
+    price: 18200,
+    description: "Programme annuel avec cellule contenue, live et data storytelling",
+    deliverables: ["Retainer production mensuelle", "Live trimestriels Seedance", "Veille trends + optimisation"],
+    sla: "Équipe dédiée & dashboard 24/7",
+  },
+];
+
+const initialClients: ClientAccount[] = [
+  {
+    id: uuid(),
+    name: "Lena Photon",
+    email: "lena@quantumwear.ai",
+    password: "studioVBG!",
+    company: "QuantumWear",
+    industry: "Tech santé",
+    membership: "Hyperdrive",
+    avatarHue: 182,
+    lastProject: "Sillage Quantique",
+  },
+];
+
+const initialQuotes: QuoteRequest[] = [
+  {
+    id: uuid(),
+    clientId: initialClients[0].id,
+    clientName: initialClients[0].name,
+    projectName: "Activation wearable SXSW",
+    budgetRange: "12k€ - 18k€",
+    deadline: "2025-03-11",
+    services: ["Captation multicam", "IA scénarisation", "Pack réseaux"],
+    status: "en revue",
+    moodboardPrompt:
+      "Imagine a slow-motion capture of biometric data turning into aurora borealis patterns inside a dome stage.",
+    createdAt: new Date().toISOString(),
+  },
+];
+
+const initialChats: ChatThread[] = [
+  {
+    quoteId: initialQuotes[0].id,
+    clientName: initialClients[0].name,
+    projectName: initialQuotes[0].projectName,
+    messages: [
+      {
+        id: uuid(),
+        from: "client",
+        content: "On peut ajouter une version 9:16 verticale ?",
+        timestamp: new Date().toISOString(),
+      },
+      {
+        id: uuid(),
+        from: "studio",
+        content: "Bien sûr, on la génère via Veo 3 + montage Davinci. Je t'envoie le chiffrage dans 5 minutes.",
+        timestamp: new Date().toISOString(),
+      },
+    ],
+  },
+];
+
+const StudioProvider = ({ children }: { children: ReactNode }) => {
+  const [user, setUser] = useState<ClientAccount | null>(null);
+  const [clients, setClients] = useState<ClientAccount[]>(initialClients);
+  const [portfolioItems, setPortfolioItems] = useState<PortfolioItem[]>(initialPortfolio);
+  const [pricingTiers, setPricingTiers] = useState<PricingTier[]>(initialPricing);
+  const [quoteRequests, setQuoteRequests] = useState<QuoteRequest[]>(initialQuotes);
+  const [contactRequests, setContactRequests] = useState<ContactRequest[]>([]);
+  const [chats, setChats] = useState<ChatThread[]>(initialChats);
+
+  const register: StudioContextValue["register"] = (payload) => {
+    const { email } = payload;
+    const exists = clients.some((client) => client.email === email);
+    if (exists) {
+      return { success: false, message: "Un compte utilise déjà cet email." };
+    }
+
+    const newClient: ClientAccount = {
+      ...payload,
+      id: uuid(),
+      avatarHue: Math.floor(Math.random() * 360),
+    };
+
+    setClients((prev) => [...prev, newClient]);
+    setUser(newClient);
+
+    return { success: true };
+  };
+
+  const login: StudioContextValue["login"] = (email, password) => {
+    const found = clients.find((client) => client.email === email && client.password === password);
+    if (!found) {
+      return { success: false, message: "Identifiants invalides ou compte inexistant." };
+    }
+
+    setUser(found);
+    return { success: true };
+  };
+
+  const logout = () => setUser(null);
+
+  const addPortfolioItem: StudioContextValue["addPortfolioItem"] = ({ gradient, ...payload }) => {
+    const newItem: PortfolioItem = {
+      ...payload,
+      id: uuid(),
+      gradient: gradient ?? gradientPool[Math.floor(Math.random() * gradientPool.length)],
+    };
+
+    setPortfolioItems((prev) => [newItem, ...prev]);
+  };
+
+  const updatePortfolioItem: StudioContextValue["updatePortfolioItem"] = (id, updates) => {
+    setPortfolioItems((prev) => prev.map((item) => (item.id === id ? { ...item, ...updates } : item)));
+  };
+
+  const removePortfolioItem: StudioContextValue["removePortfolioItem"] = (id) => {
+    setPortfolioItems((prev) => prev.filter((item) => item.id !== id));
+  };
+
+  const updatePricingTier: StudioContextValue["updatePricingTier"] = (id, updates) => {
+    setPricingTiers((prev) => prev.map((tier) => (tier.id === id ? { ...tier, ...updates } : tier)));
+  };
+
+  const createQuoteRequest: StudioContextValue["createQuoteRequest"] = (payload) => {
+    if (!user) return null;
+
+    const newQuote: QuoteRequest = {
+      ...payload,
+      id: uuid(),
+      clientId: user.id,
+      clientName: user.name,
+      status: "nouveau",
+      createdAt: new Date().toISOString(),
+    };
+
+    setQuoteRequests((prev) => [newQuote, ...prev]);
+    return newQuote;
+  };
+
+  const ensureChatThread = (quoteId: string, clientName: string, projectName: string) => {
+    setChats((prev) => {
+      const exists = prev.some((thread) => thread.quoteId === quoteId);
+      if (exists) return prev;
+      return [
+        ...prev,
+        {
+          quoteId,
+          clientName,
+          projectName,
+          messages: [
+            {
+              id: uuid(),
+              from: "studio",
+              content: "Hello ! On ouvre le canal pour affiner ton projet.",
+              timestamp: new Date().toISOString(),
+            },
+          ],
+        },
+      ];
+    });
+  };
+
+  const advanceQuoteStatus: StudioContextValue["advanceQuoteStatus"] = (id, status) => {
+    setQuoteRequests((prev) =>
+      prev.map((quote) => {
+        if (quote.id === id) {
+          if (status === "validé") {
+            ensureChatThread(quote.id, quote.clientName, quote.projectName);
+          }
+          return { ...quote, status };
+        }
+        return quote;
+      }),
+    );
+  };
+
+  const appendChatMessage: StudioContextValue["appendChatMessage"] = (quoteId, message) => {
+    setChats((prev) =>
+      prev.map((thread) =>
+        thread.quoteId === quoteId
+          ? {
+              ...thread,
+              messages: [
+                ...thread.messages,
+                {
+                  ...message,
+                  id: uuid(),
+                  timestamp: new Date().toISOString(),
+                },
+              ],
+            }
+          : thread,
+      ),
+    );
+  };
+
+  const recordContactRequest: StudioContextValue["recordContactRequest"] = (payload) => {
+    const newRequest: ContactRequest = {
+      ...payload,
+      id: uuid(),
+      createdAt: new Date().toISOString(),
+    };
+
+    setContactRequests((prev) => [newRequest, ...prev]);
+  };
+
+  const value: StudioContextValue = {
+    user,
+    clients,
+    portfolioItems,
+    pricingTiers,
+    quoteRequests,
+    contactRequests,
+    chats,
+    register,
+    login,
+    logout,
+    addPortfolioItem,
+    updatePortfolioItem,
+    removePortfolioItem,
+    updatePricingTier,
+    createQuoteRequest,
+    advanceQuoteStatus,
+    appendChatMessage,
+    recordContactRequest,
+  };
+
+  return <StudioContext.Provider value={value}>{children}</StudioContext.Provider>;
+};
+
+const useStudio = () => {
+  const context = useContext(StudioContext);
+  if (!context) {
+    throw new Error("useStudio doit être utilisé dans un StudioProvider");
+  }
+  return context;
+};
+
+export { StudioProvider, useStudio };

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -1,0 +1,38 @@
+export const navigationItems = [
+  {
+    label: "Accueil",
+    to: "/",
+    emoji: "🚀",
+    tooltip: "Landing synthwave",
+  },
+  {
+    label: "Services",
+    to: "/services",
+    emoji: "🎬",
+    tooltip: "Pipeline 2025",
+  },
+  {
+    label: "Playground IA",
+    to: "/playground",
+    emoji: "🤖",
+    tooltip: "R&D Midjourney + Kling",
+  },
+  {
+    label: "Portfolio",
+    to: "/portfolio",
+    emoji: "📼",
+    tooltip: "Cas pratiques",
+  },
+  {
+    label: "Process",
+    to: "/process",
+    emoji: "🛰️",
+    tooltip: "Méthode orbitale",
+  },
+  {
+    label: "Dashboard",
+    to: "/dashboard",
+    emoji: "🛠️",
+    tooltip: "Back-office",
+  },
+];

--- a/src/lib/services.ts
+++ b/src/lib/services.ts
@@ -1,0 +1,130 @@
+export type ServiceDetail = {
+  slug: string;
+  title: string;
+  subtitle: string;
+  problem: string;
+  promise: string;
+  stack: string[];
+  deliverables: string[];
+  phases: {
+    title: string;
+    description: string;
+    aiUpgrade: string;
+  }[];
+  signatureMove: string;
+  metrics: { label: string; value: string; note: string }[];
+};
+
+export const servicesData: ServiceDetail[] = [
+  {
+    slug: "captation-spectrale",
+    title: "Captation Spectrale",
+    subtitle: "Multi-cam, drone neurone et plateau XR synchronisé",
+    problem: "Vous avez un événement, un lancement, un live. Mais vous refusez que cela ressemble à un livestream Zoom 2020.",
+    promise:
+      "Nous transformons chaque captation en matière noire cinématographique : caméra robotisée, suivi volumétrique Seedance Pro et compositing temps réel.",
+    stack: ["Seedance Pro", "DaVinci Resolve", "Blackmagic Atem Scripting", "Audio Suno AI"],
+    deliverables: [
+      "Réalisations live multi-cam 12K",
+      "Mixage audio spatial et stems Suno",
+      "Capsules sociales instantanées",
+    ],
+    phases: [
+      {
+        title: "Pré-show quantique",
+        description: "Scouting via LiDAR, mapping lumière IA et écriture dramaturgique avec GPT Cinematic.",
+        aiUpgrade: "Modélisation 3D Midjourney V7 + previs animée Kling 2.5.",
+      },
+      {
+        title: "Jour J orchestré",
+        description: "Pilotage robotique, switcher automatisé par gestes, overlay data en direct.",
+        aiUpgrade: "Seedance Pro prédit les mouvements clés pour anticiper les changements d'angle.",
+      },
+      {
+        title: "Afterglow instantané",
+        description: "Montage express, VFX Veo 3 et publication orchestrée via nos automations.",
+        aiUpgrade: "IA narrative qui génère punchlines et CTA adaptés par réseau.",
+      },
+    ],
+    signatureMove: "Nous livrons une version 9:16 optimisée dans les 47 minutes post-show.",
+    metrics: [
+      { label: "Switchs caméra", value: "480", note: "gérés par prédiction gestuelle" },
+      { label: "Équipe plateau", value: "6", note: "dont 2 IA operators" },
+      { label: "Taux de rétention", value: "+63%", note: "vs livestream standard" },
+    ],
+  },
+  {
+    slug: "campagne-holo-sociale",
+    title: "Campagne Holo-Sociale",
+    subtitle: "Brand content orbitant sur tous les réseaux en 6 formats",
+    problem: "Vos audiences scrollent à 200 km/h. Il faut un crochet, un running gag, un plan que personne n'a vu.",
+    promise:
+      "Nous fusionnons humour, motion design et IA générative pour créer un storytelling modulable qui respire 2025.",
+    stack: ["Midjourney V7", "Veo 3", "Adobe After Effects", "Premiere Pro Sensei"],
+    deliverables: [
+      "Film héro + 12 snack content",
+      "Memes corporate prêts à poster",
+      "Banque de visuels IA brandés",
+    ],
+    phases: [
+      {
+        title: "Narrative Lab",
+        description: "Atelier de hooks, persona memetics, copywriting borderline mais on gère.",
+        aiUpgrade: "Prompt engineering Midjourney V7 & GPT-Voix pour script multi-tonalité.",
+      },
+      {
+        title: "Tournage & capture humour",
+        description: "Plan-séquence, drones indoor, comédiens, avatars lip-sync.",
+        aiUpgrade: "LypSync V2 synchronise dialogues et improvisations générées.",
+      },
+      {
+        title: "Déclinaisons fulgurantes",
+        description: "Montage modulaire, VFX data-driven, automation de publication.",
+        aiUpgrade: "Veille tendance en temps réel pour booster chaque format.",
+      },
+    ],
+    signatureMove: "Un gag métaverse caché dans chaque version 9:16. Les fans en redemandent.",
+    metrics: [
+      { label: "Temps de prod", value: "12 jours", note: "du brief au drop" },
+      { label: "Variations IA", value: "128", note: "prompts optimisés en live" },
+      { label: "UGC généré", value: "x4", note: "vs campagne classique" },
+    ],
+  },
+  {
+    slug: "programme-continuum",
+    title: "Programme Continuum",
+    subtitle: "Studio vidéo externe pour votre marque sur 12 mois",
+    problem: "Vous voulez une présence vidéo constante sans monter une équipe interne de 12 personnes.",
+    promise:
+      "Studio VBG devient votre cellule de création : plan editorial, tournages mensuels, lives trimestriels et veille tendances.",
+    stack: ["DaVinci Resolve", "Notion Automations", "Adobe Premiere Pro", "Veo 3", "Kling 2.5"],
+    deliverables: [
+      "Roadmap éditoriale évolutive",
+      "Plateau captation récurrent",
+      "Dashboard ROI et insights",
+    ],
+    phases: [
+      {
+        title: "Onboarding orbite",
+        description: "Audit contenus, modélisation audience, définition KPIs.",
+        aiUpgrade: "Analyse sémantique GPT+ pour détecter les angles différenciants.",
+      },
+      {
+        title: "Production vivante",
+        description: "Captations mensuelles, micros contenus, live event trimestriel.",
+        aiUpgrade: "Planification automatisée et scripts IA personnalisés.",
+      },
+      {
+        title: "Optimisation continue",
+        description: "Analyse de performance, suggestions IA, refonte créative.",
+        aiUpgrade: "Dashboard React + IA pour recommandations en 1 clic.",
+      },
+    ],
+    signatureMove: "Une rétro mensuelle stand-up pour célébrer les fails qui marchent.",
+    metrics: [
+      { label: "Période", value: "12 mois", note: "renouvelable" },
+      { label: "ROI moyen", value: "x5.6", note: "sur les leads inbound" },
+      { label: "Taux de stress", value: "-73%", note: "mesuré chez vos équipes marketing" },
+    ],
+  },
+];

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -1,0 +1,190 @@
+import { FormEvent, useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useStudio } from "@/context/StudioContext";
+
+const Auth = () => {
+  const [mode, setMode] = useState<"login" | "register">("register");
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const { register: registerUser, login, user } = useStudio();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const redirectPath = (location.state as { from?: string })?.from ?? "/dashboard";
+
+  const [form, setForm] = useState({
+    name: "",
+    email: "",
+    password: "",
+    company: "",
+    industry: "",
+    membership: "Hyperdrive" as const,
+  });
+
+  useEffect(() => {
+    if (user) {
+      navigate(redirectPath, { replace: true });
+    }
+  }, [user, navigate, redirectPath]);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setSuccess(null);
+
+    if (mode === "register") {
+      if (!form.name || !form.email || !form.password) {
+        setError("Merci de remplir tous les champs indispensables.");
+        return;
+      }
+      const response = registerUser(form);
+      if (response.success) {
+        setSuccess("Bienvenue à bord ! Vous êtes connecté·e.");
+      } else {
+        setError(response.message ?? "Impossible de créer le compte.");
+      }
+    } else {
+      const response = login(form.email, form.password);
+      if (!response.success) {
+        setError(response.message ?? "Impossible de se connecter.");
+      } else {
+        setSuccess("Connexion réussie. Préparez votre brief !");
+      }
+    }
+  };
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-white">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_10%_10%,rgba(14,165,233,0.2),transparent_60%)]" />
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_90%_90%,rgba(236,72,153,0.2),transparent_60%)]" />
+      <div className="relative mx-auto grid max-w-6xl grid-cols-1 gap-10 px-6 pb-24 pt-28 lg:grid-cols-[1.2fr_1fr]">
+        <div className="rounded-[3rem] border border-white/10 bg-white/5 p-12 shadow-[0_25px_120px_rgba(14,165,233,0.2)]">
+          <div className="space-y-6">
+            <span className="inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.35em] text-cyan-100/80">
+              Studio VBG · Espace client
+            </span>
+            <h1 className="text-5xl font-black leading-tight">Préparez votre orbit</h1>
+            <p className="text-lg text-slate-200/80">
+              Créez votre compte ou connectez-vous pour accéder au dashboard, envoyer un brief, suivre vos devis et chatter avec nos équipes.
+            </p>
+            <div className="grid gap-4 text-sm text-slate-200/70 sm:grid-cols-2">
+              <div className="rounded-3xl border border-white/10 bg-white/10 p-5">
+                <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70">Onboarding fun</p>
+                <p className="mt-2">On vous pose une question icebreaker pour chaque projet.</p>
+              </div>
+              <div className="rounded-3xl border border-white/10 bg-white/10 p-5">
+                <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70">Sécurité simple</p>
+                <p className="mt-2">Vos données restent chez nous, pas de partage sauvage.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <form
+          className="space-y-6 rounded-[3rem] border border-white/10 bg-white/10 p-10 shadow-[0_20px_100px_rgba(236,72,153,0.2)]"
+          onSubmit={handleSubmit}
+        >
+          <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-slate-200/70">
+            <span>{mode === "register" ? "Créer un compte" : "Connexion"}</span>
+            <button
+              type="button"
+              onClick={() => {
+                setMode((prev) => (prev === "register" ? "login" : "register"));
+                setError(null);
+                setSuccess(null);
+              }}
+              className="rounded-full border border-white/20 px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-white"
+            >
+              {mode === "register" ? "J'ai déjà un compte" : "Créer un compte"}
+            </button>
+          </div>
+
+          {mode === "register" && (
+            <div className="space-y-4">
+              <div>
+                <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Nom complet</label>
+                <input
+                  className="mt-2 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:border-cyan-400 focus:outline-none"
+                  value={form.name}
+                  onChange={(event) => setForm((prev) => ({ ...prev, name: event.target.value }))}
+                  placeholder="Ada Photon"
+                  required
+                />
+              </div>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div>
+                  <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Entreprise</label>
+                  <input
+                    className="mt-2 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:border-cyan-400 focus:outline-none"
+                    value={form.company}
+                    onChange={(event) => setForm((prev) => ({ ...prev, company: event.target.value }))}
+                    placeholder="FutureCorp"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Secteur</label>
+                  <input
+                    className="mt-2 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:border-cyan-400 focus:outline-none"
+                    value={form.industry}
+                    onChange={(event) => setForm((prev) => ({ ...prev, industry: event.target.value }))}
+                    placeholder="Tech / Mode / Finance fun"
+                    required
+                  />
+                </div>
+              </div>
+              <div>
+                <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Programme</label>
+                <select
+                  className="mt-2 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:border-cyan-400 focus:outline-none"
+                  value={form.membership}
+                  onChange={(event) => setForm((prev) => ({ ...prev, membership: event.target.value as typeof prev.membership }))}
+                >
+                  <option value="Impulse">Impulse (starter)</option>
+                  <option value="Hyperdrive">Hyperdrive (campagne multi-format)</option>
+                  <option value="Continuum">Continuum (retainer annuel)</option>
+                </select>
+              </div>
+            </div>
+          )}
+
+          <div className="space-y-4">
+            <div>
+              <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Email</label>
+              <input
+                type="email"
+                className="mt-2 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:border-cyan-400 focus:outline-none"
+                value={form.email}
+                onChange={(event) => setForm((prev) => ({ ...prev, email: event.target.value }))}
+                placeholder="vous@studio2025.com"
+                required
+              />
+            </div>
+            <div>
+              <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Mot de passe</label>
+              <input
+                type="password"
+                className="mt-2 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:border-cyan-400 focus:outline-none"
+                value={form.password}
+                onChange={(event) => setForm((prev) => ({ ...prev, password: event.target.value }))}
+                placeholder="Au moins 8 caractères"
+                required
+              />
+            </div>
+          </div>
+
+          <button
+            type="submit"
+            className="group relative w-full overflow-hidden rounded-full border border-cyan-200/40 bg-cyan-500/20 px-6 py-3 text-sm font-bold uppercase tracking-[0.3em] text-white"
+          >
+            <span className="relative z-10">{mode === "register" ? "Créer mon cockpit" : "Connexion"}</span>
+            <span className="absolute inset-0 translate-x-[-120%] bg-gradient-to-r from-cyan-400 via-sky-300 to-fuchsia-400 transition-transform duration-700 group-hover:translate-x-0" />
+          </button>
+
+          {error && <p className="rounded-2xl border border-rose-200/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">{error}</p>}
+          {success && <p className="rounded-2xl border border-emerald-200/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-100">{success}</p>}
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default Auth;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,0 +1,345 @@
+import { FormEvent, useMemo, useState } from "react";
+import { useStudio } from "@/context/StudioContext";
+
+const Dashboard = () => {
+  const {
+    user,
+    clients,
+    portfolioItems,
+    pricingTiers,
+    quoteRequests,
+    contactRequests,
+    chats,
+    addPortfolioItem,
+    removePortfolioItem,
+    updatePricingTier,
+    advanceQuoteStatus,
+    appendChatMessage,
+  } = useStudio();
+
+  const [newProject, setNewProject] = useState({
+    title: "",
+    tagline: "",
+    category: "",
+    year: new Date().getFullYear(),
+    duration: "00:45",
+    description: "",
+    thumbnail: "",
+    aiTools: "",
+    deliverables: "",
+    socialStack: "",
+  });
+  const [chatInput, setChatInput] = useState("");
+  const [selectedChatId, setSelectedChatId] = useState(() => chats[0]?.quoteId ?? "");
+
+  const activeChat = useMemo(() => chats.find((chat) => chat.quoteId === selectedChatId), [chats, selectedChatId]);
+
+  if (!user) {
+    return null;
+  }
+
+  const handleAddProject = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    addPortfolioItem({
+      title: newProject.title,
+      tagline: newProject.tagline,
+      category: newProject.category || "Création",
+      year: Number(newProject.year),
+      duration: newProject.duration,
+      description: newProject.description,
+      thumbnail:
+        newProject.thumbnail || "https://images.unsplash.com/photo-1504384308090-c894fdcc538d?q=80&w=1200",
+      aiTools: newProject.aiTools.split(",").map((item) => item.trim()).filter(Boolean),
+      deliverables: newProject.deliverables.split(",").map((item) => item.trim()).filter(Boolean),
+      socialStack: newProject.socialStack.split(",").map((item) => item.trim()).filter(Boolean),
+    });
+    setNewProject({
+      title: "",
+      tagline: "",
+      category: "",
+      year: new Date().getFullYear(),
+      duration: "00:45",
+      description: "",
+      thumbnail: "",
+      aiTools: "",
+      deliverables: "",
+      socialStack: "",
+    });
+  };
+
+  const handleSendMessage = () => {
+    if (!activeChat || !chatInput.trim()) return;
+    appendChatMessage(activeChat.quoteId, { from: "studio", content: chatInput.trim() });
+    setChatInput("");
+  };
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-white">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_15%_15%,rgba(14,165,233,0.25),transparent_60%)]" />
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_85%_80%,rgba(236,72,153,0.2),transparent_60%)]" />
+      <div className="relative mx-auto max-w-7xl px-6 pb-32 pt-24">
+        <header className="rounded-[3rem] border border-white/10 bg-white/5 p-12 shadow-[0_20px_120px_rgba(14,165,233,0.2)]">
+          <div className="flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
+            <div className="space-y-6">
+              <span className="inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.35em] text-cyan-100/80">
+                Dashboard Studio VBG
+              </span>
+              <h1 className="text-5xl font-black leading-tight">Bienvenue {user.name.split(" ")[0]}</h1>
+              <p className="text-lg text-slate-200/80">
+                Gérez vos projets, suivez vos devis, ajustez vos tarifs et discutez avec nos équipes. Tout est synchronisé avec notre pipeline IA.
+              </p>
+            </div>
+            <div className="rounded-[2.5rem] border border-white/10 bg-white/10 p-8 text-sm text-slate-200/80">
+              <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70">Stat instantané</p>
+              <p className="mt-3 text-white">{portfolioItems.length} projets en cours · {quoteRequests.length} devis · {contactRequests.length} demandes rapides</p>
+            </div>
+          </div>
+        </header>
+
+        <section className="mt-16 grid gap-10 xl:grid-cols-[1.1fr_0.9fr]">
+          <div className="space-y-10">
+            <div className="rounded-[3rem] border border-white/10 bg-white/10 p-10 shadow-[0_20px_100px_rgba(56,189,248,0.18)]">
+              <h2 className="text-2xl font-bold">Ajouter un projet au portfolio</h2>
+              <p className="mt-2 text-sm text-slate-200/70">Ajoutez, modifiez, supprimez librement les projets visibles côté vitrine.</p>
+              <form className="mt-6 grid gap-4" onSubmit={handleAddProject}>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <input
+                    required
+                    value={newProject.title}
+                    onChange={(event) => setNewProject((prev) => ({ ...prev, title: event.target.value }))}
+                    placeholder="Titre"
+                    className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 focus:outline-none"
+                  />
+                  <input
+                    required
+                    value={newProject.tagline}
+                    onChange={(event) => setNewProject((prev) => ({ ...prev, tagline: event.target.value }))}
+                    placeholder="Tagline"
+                    className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 focus:outline-none"
+                  />
+                </div>
+                <div className="grid gap-4 sm:grid-cols-4">
+                  <input
+                    value={newProject.category}
+                    onChange={(event) => setNewProject((prev) => ({ ...prev, category: event.target.value }))}
+                    placeholder="Catégorie"
+                    className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 focus:outline-none"
+                  />
+                  <input
+                    value={newProject.year}
+                    type="number"
+                    onChange={(event) => setNewProject((prev) => ({ ...prev, year: Number(event.target.value) }))}
+                    placeholder="Année"
+                    className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 focus:outline-none"
+                  />
+                  <input
+                    value={newProject.duration}
+                    onChange={(event) => setNewProject((prev) => ({ ...prev, duration: event.target.value }))}
+                    placeholder="Durée"
+                    className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 focus:outline-none"
+                  />
+                  <input
+                    value={newProject.thumbnail}
+                    onChange={(event) => setNewProject((prev) => ({ ...prev, thumbnail: event.target.value }))}
+                    placeholder="URL thumbnail"
+                    className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 focus:outline-none"
+                  />
+                </div>
+                <textarea
+                  value={newProject.description}
+                  onChange={(event) => setNewProject((prev) => ({ ...prev, description: event.target.value }))}
+                  rows={3}
+                  placeholder="Description punchy"
+                  className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 focus:outline-none"
+                />
+                <div className="grid gap-4 sm:grid-cols-3">
+                  <input
+                    value={newProject.aiTools}
+                    onChange={(event) => setNewProject((prev) => ({ ...prev, aiTools: event.target.value }))}
+                    placeholder="IA tools (séparés par virgule)"
+                    className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 focus:outline-none"
+                  />
+                  <input
+                    value={newProject.deliverables}
+                    onChange={(event) => setNewProject((prev) => ({ ...prev, deliverables: event.target.value }))}
+                    placeholder="Livrables"
+                    className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 focus:outline-none"
+                  />
+                  <input
+                    value={newProject.socialStack}
+                    onChange={(event) => setNewProject((prev) => ({ ...prev, socialStack: event.target.value }))}
+                    placeholder="Stack social"
+                    className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 focus:outline-none"
+                  />
+                </div>
+                <button
+                  type="submit"
+                  className="self-start rounded-full border border-cyan-200/40 bg-cyan-500/20 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white"
+                >
+                  Ajouter au portfolio
+                </button>
+              </form>
+              <div className="mt-6 grid gap-4 text-sm text-slate-200/70 sm:grid-cols-2">
+                {portfolioItems.slice(0, 4).map((item) => (
+                  <div key={item.id} className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                    <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em]">
+                      <span>{item.category}</span>
+                      <button
+                        type="button"
+                        onClick={() => removePortfolioItem(item.id)}
+                        className="text-rose-300 hover:text-rose-200"
+                      >
+                        Supprimer
+                      </button>
+                    </div>
+                    <p className="mt-2 font-semibold text-white">{item.title}</p>
+                    <p className="text-xs text-slate-200/60">{item.tagline}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-[3rem] border border-white/10 bg-white/10 p-10 shadow-[0_20px_100px_rgba(236,72,153,0.18)]">
+              <h2 className="text-2xl font-bold">Gestion des tarifs</h2>
+              <div className="mt-6 grid gap-4 sm:grid-cols-3">
+                {pricingTiers.map((tier) => (
+                  <div key={tier.id} className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                    <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70">{tier.name}</p>
+                    <input
+                      type="number"
+                      className="mt-3 w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white focus:border-cyan-400 focus:outline-none"
+                      value={tier.price}
+                      onChange={(event) => updatePricingTier(tier.id, { price: Number(event.target.value) })}
+                    />
+                    <p className="mt-2 text-xs text-slate-200/60">{tier.description}</p>
+                    <p className="mt-2 text-xs text-slate-200/60">{tier.sla}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <aside className="space-y-10">
+            <div className="rounded-[3rem] border border-white/10 bg-white/10 p-8 shadow-[0_20px_80px_rgba(56,189,248,0.15)]">
+              <h2 className="text-2xl font-bold">Comptes clients</h2>
+              <div className="mt-4 space-y-4 text-sm text-slate-200/70">
+                {clients.map((client) => (
+                  <div key={client.id} className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="font-semibold text-white">{client.name}</p>
+                        <p className="text-xs text-slate-200/60">{client.email}</p>
+                      </div>
+                      <span className="rounded-full border border-white/20 px-3 py-1 text-xs uppercase tracking-[0.3em] text-cyan-200/80">
+                        {client.membership}
+                      </span>
+                    </div>
+                    <p className="mt-2 text-xs text-slate-200/60">{client.company} · {client.industry}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-[3rem] border border-white/10 bg-white/10 p-8 shadow-[0_20px_80px_rgba(236,72,153,0.15)]">
+              <h2 className="text-2xl font-bold">Demandes de devis</h2>
+              <div className="mt-4 space-y-4 text-sm text-slate-200/70">
+                {quoteRequests.map((quote) => (
+                  <div key={quote.id} className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="font-semibold text-white">{quote.projectName}</p>
+                        <p className="text-xs text-slate-200/60">{quote.clientName} · {quote.budgetRange}</p>
+                      </div>
+                      <select
+                        value={quote.status}
+                        onChange={(event) => advanceQuoteStatus(quote.id, event.target.value as typeof quote.status)}
+                        className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs uppercase tracking-[0.3em] text-white"
+                      >
+                        <option value="nouveau">Nouveau</option>
+                        <option value="en revue">En revue</option>
+                        <option value="validé">Validé</option>
+                        <option value="refusé">Refusé</option>
+                      </select>
+                    </div>
+                    <p className="mt-2 text-xs text-slate-200/60">Deadline : {quote.deadline}</p>
+                    <p className="mt-2 text-xs text-slate-200/60">Services : {quote.services.join(", ")}</p>
+                    <button
+                      type="button"
+                      onClick={() => setSelectedChatId(quote.id)}
+                      className="mt-3 rounded-full border border-cyan-200/40 bg-cyan-500/20 px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-white"
+                    >
+                      Ouvrir le chat
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-[3rem] border border-white/10 bg-white/10 p-8 shadow-[0_20px_80px_rgba(34,211,238,0.18)]">
+              <h2 className="text-2xl font-bold">Chat style SMS</h2>
+              <div className="mt-4 flex gap-4">
+                <div className="w-1/3 space-y-2 text-xs text-slate-200/70">
+                  {chats.map((thread) => (
+                    <button
+                      key={thread.quoteId}
+                      type="button"
+                      onClick={() => setSelectedChatId(thread.quoteId)}
+                      className={`w-full rounded-2xl border px-3 py-2 text-left ${
+                        thread.quoteId === selectedChatId ? "border-cyan-300 bg-white/20" : "border-white/10 bg-white/5"
+                      }`}
+                    >
+                      <p className="font-semibold text-white">{thread.clientName}</p>
+                      <p className="text-[0.65rem] text-slate-200/60">{thread.projectName}</p>
+                    </button>
+                  ))}
+                </div>
+                <div className="flex-1 rounded-2xl border border-white/10 bg-slate-950/60 p-4">
+                  {activeChat ? (
+                    <div className="flex h-full flex-col">
+                      <div className="flex-1 space-y-3 overflow-y-auto pr-2">
+                        {activeChat.messages.map((message) => (
+                          <div
+                            key={message.id}
+                            className={`max-w-[80%] rounded-2xl px-4 py-3 text-sm ${
+                              message.from === "studio"
+                                ? "ml-auto bg-cyan-500/20 text-cyan-100"
+                                : "bg-white/10 text-slate-100"
+                            }`}
+                          >
+                            <p>{message.content}</p>
+                            <p className="mt-1 text-[0.6rem] uppercase tracking-[0.2em] text-slate-200/50">
+                              {new Date(message.timestamp).toLocaleString()}
+                            </p>
+                          </div>
+                        ))}
+                      </div>
+                      <div className="mt-4 flex items-center gap-2">
+                        <input
+                          value={chatInput}
+                          onChange={(event) => setChatInput(event.target.value)}
+                          placeholder="Répondre avec panache"
+                          className="flex-1 rounded-full border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 focus:outline-none"
+                        />
+                        <button
+                          type="button"
+                          onClick={handleSendMessage}
+                          className="rounded-full border border-cyan-200/40 bg-cyan-500/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white"
+                        >
+                          Envoyer
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <p className="text-sm text-slate-200/70">Aucun chat sélectionné.</p>
+                  )}
+                </div>
+              </div>
+            </div>
+          </aside>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,11 +1,345 @@
-// Update this page (the content is just a fallback if you fail to update the page)
+import { Link } from "react-router-dom";
+import { useState } from "react";
+import { useStudio } from "@/context/StudioContext";
+import { servicesData } from "@/lib/services";
+
+const heroHooks = [
+  "Votre board veut du wow. On livre du *whoa*.",
+  "Les algorithmes scrollent aussi — parlons leur langage.",
+  "Les budgets n'aiment pas les tunnels sans fin. Nous non plus.",
+];
+
+const techStack = [
+  "Midjourney V7",
+  "Kling 2.5",
+  "Seedance Pro",
+  "Veo 3",
+  "Suno AI",
+  "LypSync V2",
+  "DaVinci Resolve",
+  "Adobe Video Sensei",
+];
 
 const Index = () => {
+  const { portfolioItems, recordContactRequest } = useStudio();
+  const [hookIndex, setHookIndex] = useState(0);
+  const [contactSent, setContactSent] = useState(false);
+  const [form, setForm] = useState({
+    name: "",
+    email: "",
+    projectSpark: "",
+    urgency: "hier" as const,
+  });
+
+  const heroProject = portfolioItems[0];
+
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background">
-      <div className="text-center">
-        <h1 className="mb-4 text-4xl font-bold">Welcome to Your Blank App</h1>
-        <p className="text-xl text-muted-foreground">Start building your amazing project here!</p>
+    <div className="relative min-h-screen overflow-x-hidden bg-slate-950 text-white">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(14,165,233,0.35),transparent_55%)]" />
+      <div className="pointer-events-none absolute inset-0 animate-[spin_20s_linear_infinite] bg-[conic-gradient(from_45deg_at_30%_30%,rgba(59,130,246,0.18),rgba(236,72,153,0.18),transparent_70%)]" />
+      <div className="relative">
+        <header className="mx-auto flex max-w-7xl flex-col gap-12 px-6 pt-20 pb-28 lg:flex-row lg:items-center">
+          <div className="flex-1 space-y-10">
+            <span className="inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.35em] text-slate-200 backdrop-blur">
+              Studio VBG · Agence vidéaste 2025
+            </span>
+            <h1 className="text-4xl font-black leading-tight sm:text-6xl">
+              <span className="bg-gradient-to-r from-cyan-400 via-sky-200 to-fuchsia-400 bg-clip-text text-transparent">
+                Studio VBG
+              </span>{" "}
+              orchestre vos contenus vidéo comme un{' '}
+              <span className="underline decoration-wavy decoration-cyan-300">thriller orbital</span>.
+            </h1>
+            <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-6 text-lg leading-relaxed shadow-[0_0_60px_rgba(56,189,248,0.25)]">
+              <div className="absolute inset-y-0 right-0 w-px bg-gradient-to-b from-transparent via-white/30 to-transparent" />
+              <p className="font-semibold uppercase tracking-[0.2em] text-cyan-200/80">Hook du moment</p>
+              <p className="mt-4 text-2xl" onMouseEnter={() => setHookIndex((i) => (i + 1) % heroHooks.length)}>
+                {heroHooks[hookIndex]}
+              </p>
+              <p className="mt-6 text-sm text-slate-200/80">
+                Nous mixons humour calibré, pipeline IA et équipes plateau pour que vos stories deviennent des franchises.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-4">
+              <Link
+                to="/quote"
+                className="group relative overflow-hidden rounded-full border border-cyan-200/30 bg-cyan-500/20 px-8 py-4 text-sm font-bold uppercase tracking-[0.3em] text-cyan-100 shadow-[0_10px_40px_rgba(8,145,178,0.35)] transition hover:scale-105"
+              >
+                <span className="relative z-10 flex items-center gap-3">
+                  <span className="text-xl">⚡</span> Demande de devis quantique
+                </span>
+                <span className="absolute inset-0 -z-0 translate-y-full bg-gradient-to-r from-cyan-400 via-sky-300 to-fuchsia-500 transition-all duration-500 group-hover:translate-y-0" />
+              </Link>
+              <a
+                href="#contact"
+                className="group relative overflow-hidden rounded-full border border-white/20 px-8 py-4 text-sm font-bold uppercase tracking-[0.3em] text-white transition hover:scale-105"
+              >
+                <span className="relative z-10 flex items-center gap-3">
+                  <span className="text-xl">📞</span> Demande rapide
+                </span>
+                <span className="absolute inset-0 -z-0 translate-y-full bg-white/20 transition-all duration-500 group-hover:translate-y-0" />
+              </a>
+            </div>
+            <div className="grid gap-4 text-sm text-slate-300/80 sm:grid-cols-2">
+              <div className="rounded-3xl border border-white/10 bg-white/5 p-4 backdrop-blur">
+                <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70">Pipeline IA</p>
+                <p className="mt-2 font-semibold text-white">Midjourney V7 · Kling 2.5 · Seedance Pro · Veo 3 · Suno AI · LypSync V2</p>
+              </div>
+              <div className="rounded-3xl border border-white/10 bg-white/5 p-4 backdrop-blur">
+                <p className="text-xs uppercase tracking-[0.3em] text-fuchsia-200/70">Résultats 2024</p>
+                <p className="mt-2 font-semibold text-white">+320% d'engagement moyen · 48h pour produire un bundle complet</p>
+              </div>
+            </div>
+          </div>
+          <div className="flex flex-1 flex-col gap-6">
+            <div className="relative overflow-hidden rounded-[2.5rem] border border-white/10 bg-white/5 p-6 shadow-[0_30px_120px_rgba(236,72,153,0.2)]">
+              <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,rgba(236,72,153,0.3),transparent_65%)]" />
+              <div className="relative space-y-6">
+                <p className="text-xs uppercase tracking-[0.4em] text-fuchsia-200/70">Cas phare</p>
+                <h2 className="text-2xl font-bold leading-tight">{heroProject?.title}</h2>
+                <p className="text-slate-200/80">{heroProject?.tagline}</p>
+                <div className="grid gap-3 text-xs font-semibold uppercase tracking-[0.2em] text-slate-200/70 sm:grid-cols-3">
+                  <div className="rounded-2xl bg-white/5 p-3 text-center">{heroProject?.category}</div>
+                  <div className="rounded-2xl bg-white/5 p-3 text-center">{heroProject?.duration}</div>
+                  <div className="rounded-2xl bg-white/5 p-3 text-center">{heroProject?.year}</div>
+                </div>
+                <img
+                  src={heroProject?.thumbnail}
+                  alt={heroProject?.title}
+                  className="h-64 w-full rounded-[2rem] object-cover object-center"
+                />
+                <div className="flex flex-wrap gap-2 text-xs text-cyan-100/80">
+                  {heroProject?.aiTools.map((tool) => (
+                    <span key={tool} className="rounded-full bg-cyan-500/20 px-3 py-1">{tool}</span>
+                  ))}
+                </div>
+              </div>
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2">
+              {techStack.slice(0, 4).map((tool) => (
+                <div key={tool} className="rounded-3xl border border-white/10 bg-gradient-to-br from-white/10 to-white/5 p-4">
+                  <p className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Stack</p>
+                  <p className="mt-2 text-lg font-bold text-white">{tool}</p>
+                  <p className="text-[0.75rem] text-slate-200/70">Automatisé, documenté, prêt pour vos contenus.</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </header>
+
+        <section className="relative mx-auto max-w-6xl px-6 pb-24">
+          <div className="absolute inset-0 -z-10 blur-3xl" style={{ background: "radial-gradient(circle at 20% 20%, rgba(6,182,212,0.15), transparent 60%)" }} />
+          <div className="rounded-[3rem] border border-white/10 bg-white/5 p-10 shadow-[0_0_80px_rgba(59,130,246,0.15)]">
+            <div className="flex flex-col items-start gap-6 pb-10 lg:flex-row lg:items-center lg:justify-between">
+              <div>
+                <p className="text-sm uppercase tracking-[0.3em] text-cyan-200/70">Pipeline orchestré</p>
+                <h2 className="mt-3 text-4xl font-extrabold">
+                  Une stack IA + plateau réel calibrée pour faire sourire vos KPIs
+                </h2>
+              </div>
+              <div className="flex gap-3 text-sm text-slate-200/80">
+                {techStack.map((tool) => (
+                  <span
+                    key={tool}
+                    className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-3 py-1"
+                  >
+                    <span className="h-2 w-2 rounded-full bg-cyan-300" /> {tool}
+                  </span>
+                ))}
+              </div>
+            </div>
+            <div className="grid gap-6 lg:grid-cols-3">
+              {servicesData.map((service, index) => (
+                <Link
+                  key={service.slug}
+                  to={`/services/${service.slug}`}
+                  className="group relative overflow-hidden rounded-[2rem] border border-white/10 bg-gradient-to-br from-white/10 to-white/5 p-8 shadow-[0_30px_100px_rgba(56,189,248,0.12)] transition-transform duration-500 hover:-translate-y-2"
+                >
+                  <span className="absolute inset-0 translate-y-full bg-gradient-to-t from-cyan-500/30 via-transparent to-transparent transition-transform duration-700 group-hover:translate-y-0" />
+                  <div className="relative space-y-4">
+                    <span className="inline-flex items-center gap-3 text-sm font-semibold text-cyan-200/80">
+                      <span className="text-2xl">0{index + 1}</span> {service.title}
+                    </span>
+                    <p className="text-xl font-bold text-white">{service.subtitle}</p>
+                    <p className="text-sm text-slate-200/80">{service.promise}</p>
+                    <div className="flex flex-wrap gap-2 text-xs text-cyan-100/70">
+                      {service.stack.map((tool) => (
+                        <span key={tool} className="rounded-full bg-cyan-500/10 px-3 py-1">
+                          {tool}
+                        </span>
+                      ))}
+                    </div>
+                    <p className="text-xs uppercase tracking-[0.3em] text-slate-300/70">
+                      Lire la méthode →
+                    </p>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="relative mx-auto max-w-6xl px-6 pb-24">
+          <div className="flex flex-col gap-10 lg:flex-row">
+            <div className="flex-1 space-y-6">
+              <p className="text-sm uppercase tracking-[0.3em] text-fuchsia-200/70">Réalisations atypiques</p>
+              <h2 className="text-4xl font-extrabold leading-tight">
+                Portfolio modulable, prêt à être remixé, supprimé, amélioré en un clic
+              </h2>
+              <p className="text-lg text-slate-200/80">
+                Chaque projet est pensé comme un kit LEGO vidéo : vous pouvez ajouter, modifier, supprimer les blocs depuis notre dashboard.
+              </p>
+              <div className="grid gap-4 text-sm text-slate-200/80">
+                <div className="rounded-3xl border border-white/10 bg-white/5 p-5">
+                  <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/60">Humour & brise-glace</p>
+                  <p className="mt-2">Avant chaque tournage on joue à deviner le prompt Midjourney du client. Spoiler : on gagne souvent.</p>
+                </div>
+                <div className="rounded-3xl border border-white/10 bg-white/5 p-5">
+                  <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/60">Organisation atypique</p>
+                  <p className="mt-2">Clusters thématiques, scoring IA, et playlist Suno AI pour caler le rythme des séquences.</p>
+                </div>
+              </div>
+              <Link
+                to="/portfolio"
+                className="inline-flex items-center gap-3 rounded-full border border-fuchsia-200/40 bg-fuchsia-500/20 px-6 py-3 text-sm font-semibold uppercase tracking-[0.25em] text-white shadow-[0_15px_50px_rgba(236,72,153,0.3)]"
+              >
+                Explorer la galerie complète
+              </Link>
+            </div>
+            <div className="flex-1 space-y-6">
+              {portfolioItems.slice(0, 3).map((project, index) => (
+                <article
+                  key={project.id}
+                  className={`group relative overflow-hidden rounded-[2.5rem] border border-white/10 bg-gradient-to-br from-white/10 to-white/5 p-6 shadow-[0_25px_90px_rgba(244,114,182,0.12)] transition-all duration-500 hover:-translate-y-2 hover:shadow-[0_35px_120px_rgba(14,165,233,0.2)]`}
+                >
+                  <span className="absolute inset-0 -z-10 opacity-0 transition-opacity duration-700 group-hover:opacity-100" style={{ background: `linear-gradient(120deg, rgba(56,189,248,0.25), rgba(236,72,153,0.2))` }} />
+                  <div className="relative flex flex-col gap-4">
+                    <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-slate-200/70">
+                      <span>Projet 0{index + 1}</span>
+                      <span>{project.category}</span>
+                    </div>
+                    <h3 className="text-2xl font-bold text-white">{project.title}</h3>
+                    <p className="text-sm text-slate-200/80">{project.description}</p>
+                    <div className="grid gap-3 text-xs text-cyan-100/80 sm:grid-cols-3">
+                      <div className="rounded-2xl bg-white/5 p-3 text-center">{project.duration}</div>
+                      <div className="rounded-2xl bg-white/5 p-3 text-center">{project.year}</div>
+                      <div className="rounded-2xl bg-white/5 p-3 text-center">{project.socialStack[0]}</div>
+                    </div>
+                    <img src={project.thumbnail} alt={project.title} className="h-56 w-full rounded-[2rem] object-cover" />
+                  </div>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="relative mx-auto max-w-6xl px-6 pb-24" id="contact">
+          <div className="rounded-[3rem] border border-white/10 bg-gradient-to-br from-white/10 to-white/5 p-10 shadow-[0_25px_100px_rgba(8,145,178,0.18)]">
+            <div className="grid gap-10 lg:grid-cols-[1.2fr_1fr]">
+              <div className="space-y-6">
+                <p className="text-sm uppercase tracking-[0.3em] text-cyan-200/70">Demande rapide</p>
+                <h2 className="text-4xl font-extrabold leading-tight">
+                  90 secondes pour nous briefer. On vous rappelle avant que votre café refroidisse.
+                </h2>
+                <div className="grid gap-4 text-sm text-slate-200/80">
+                  <div className="rounded-3xl border border-white/10 bg-white/5 p-5">
+                    <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/60">Break the ice</p>
+                    <p className="mt-2">On veut tout savoir : votre running gag préféré, vos pires tournages, vos deadlines absurdes.</p>
+                  </div>
+                  <div className="rounded-3xl border border-white/10 bg-white/5 p-5">
+                    <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/60">Synergie intelligente</p>
+                    <p className="mt-2">Votre brief est injecté dans notre cockpit : IA, plateau, copywriters. Tout le monde est alerté.</p>
+                  </div>
+                </div>
+              </div>
+              <form
+                className="space-y-4"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  recordContactRequest(form);
+                  setContactSent(true);
+                  setForm({ name: "", email: "", projectSpark: "", urgency: "hier" });
+                }}
+              >
+                <div>
+                  <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Nom / pseudo</label>
+                  <input
+                    required
+                    value={form.name}
+                    onChange={(event) => setForm((prev) => ({ ...prev, name: event.target.value }))}
+                    className="mt-2 w-full rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-white placeholder:text-slate-300/60 focus:border-cyan-400 focus:outline-none"
+                    placeholder="Jane Photon ou CEO qui n'a pas dormi"
+                  />
+                </div>
+                <div>
+                  <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Email</label>
+                  <input
+                    type="email"
+                    required
+                    value={form.email}
+                    onChange={(event) => setForm((prev) => ({ ...prev, email: event.target.value }))}
+                    className="mt-2 w-full rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-white placeholder:text-slate-300/60 focus:border-cyan-400 focus:outline-none"
+                    placeholder="vous@futurebrand.com"
+                  />
+                </div>
+                <div>
+                  <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Étincelle</label>
+                  <textarea
+                    required
+                    value={form.projectSpark}
+                    onChange={(event) => setForm((prev) => ({ ...prev, projectSpark: event.target.value }))}
+                    rows={4}
+                    className="mt-2 w-full rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-white placeholder:text-slate-300/60 focus:border-cyan-400 focus:outline-none"
+                    placeholder="On veut un plan séquence avec un chatbot sarcastique qui fait des saltos"
+                  />
+                </div>
+                <div>
+                  <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Urgence</label>
+                  <select
+                    value={form.urgency}
+                    onChange={(event) => setForm((prev) => ({ ...prev, urgency: event.target.value as typeof form.urgency }))}
+                    className="mt-2 w-full rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-white focus:border-cyan-400 focus:outline-none"
+                  >
+                    <option value="hier">Il fallait hier</option>
+                    <option value="cette-semaine">Cette semaine</option>
+                    <option value="quand-c-est-parfait">Quand c'est parfait</option>
+                  </select>
+                </div>
+                <button
+                  type="submit"
+                  className="group relative w-full overflow-hidden rounded-full border border-cyan-200/40 bg-cyan-500/20 px-6 py-3 text-sm font-bold uppercase tracking-[0.3em] text-white"
+                >
+                  <span className="relative z-10">Envoyer ma demande fulgurante</span>
+                  <span className="absolute inset-0 translate-x-[-120%] bg-gradient-to-r from-cyan-400 via-sky-300 to-fuchsia-400 transition-transform duration-700 group-hover:translate-x-0" />
+                </button>
+                {contactSent && (
+                  <p className="rounded-2xl border border-cyan-200/30 bg-cyan-500/10 px-4 py-3 text-sm text-cyan-100">
+                    Merci ! Notre équipe vous répond avec un meme personnalisé sous 2 heures.
+                  </p>
+                )}
+              </form>
+            </div>
+          </div>
+        </section>
+
+        <footer className="mx-auto max-w-6xl px-6 pb-16">
+          <div className="rounded-[2.5rem] border border-white/10 bg-white/5 p-10 text-sm text-slate-200/70">
+            <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+              <div>
+                <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70">Studio VBG</p>
+                <p className="mt-2 text-lg text-white">Agence de production, captation vidéo, création de contenus réseaux sociaux.</p>
+              </div>
+              <div className="flex gap-4 text-xs uppercase tracking-[0.3em] text-slate-300/80">
+                <Link to="/process" className="hover:text-white">Méthode</Link>
+                <Link to="/services" className="hover:text-white">Services</Link>
+                <Link to="/dashboard" className="hover:text-white">Dashboard</Link>
+              </div>
+              <div className="text-xs text-slate-300/80">
+                © {new Date().getFullYear()} Studio VBG · Pipeline alimenté par IA et bon café.
+              </div>
+            </div>
+          </div>
+        </footer>
       </div>
     </div>
   );

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,4 +1,4 @@
-import { useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { useEffect } from "react";
 
 const NotFound = () => {
@@ -9,13 +9,21 @@ const NotFound = () => {
   }, [location.pathname]);
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-100">
-      <div className="text-center">
-        <h1 className="mb-4 text-4xl font-bold">404</h1>
-        <p className="mb-4 text-xl text-gray-600">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 underline hover:text-blue-700">
-          Return to Home
-        </a>
+    <div className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden bg-slate-950 text-white">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(236,72,153,0.2),transparent_60%)]" />
+      <div className="pointer-events-none absolute inset-0 animate-[spin_30s_linear_infinite] bg-[conic-gradient(from_45deg,rgba(56,189,248,0.15),transparent_60%)]" />
+      <div className="relative max-w-xl space-y-6 rounded-[3rem] border border-white/10 bg-white/5 p-12 text-center shadow-[0_20px_120px_rgba(56,189,248,0.2)]">
+        <span className="text-xs uppercase tracking-[0.35em] text-cyan-100/80">Erreur 404</span>
+        <h1 className="text-5xl font-black">Cette page tourne encore en post-prod</h1>
+        <p className="text-lg text-slate-200/80">
+          On dirait que vous avez trouvé un espace vide dans notre storyboard. Revenez à l'accueil et lançons une nouvelle scène.
+        </p>
+        <Link
+          to="/"
+          className="inline-flex items-center gap-3 rounded-full border border-cyan-200/40 bg-cyan-500/20 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white"
+        >
+          Retour au vaisseau
+        </Link>
       </div>
     </div>
   );

--- a/src/pages/Playground.tsx
+++ b/src/pages/Playground.tsx
@@ -1,0 +1,134 @@
+import { useState } from "react";
+
+const labs = [
+  {
+    id: "midjourney",
+    title: "Midjourney V7 - Prompt Lab",
+    punchline: "On fait sourire vos board members avec des planches qui respirent la SF raffinée.",
+    description:
+      "Moodboards générés, re-colorisés et animés. Nous mixons prompts narratifs et contraintes brand pour produire des planches qui donnent envie d'approuver le budget.",
+    upgrades: [
+      "Variations dynamiques par persona",
+      "Palette synchronisée avec votre brandbook",
+      "Export storyboard animé en 45 secondes",
+    ],
+    ambient: "bg-[radial-gradient(circle_at_top,rgba(59,130,246,0.3),transparent_70%)]",
+  },
+  {
+    id: "kling",
+    title: "Kling 2.5 - Volumetric Stage",
+    punchline: "On simule le plateau avant même de le louer.",
+    description:
+      "Prévisualisation 3D, trajectoires de caméras automatisées, éclairage calculé par IA. Vous voyez votre shoot avant même qu'on appuie sur REC.",
+    upgrades: [
+      "Pathfinding caméra autonome",
+      "Simulation lumière temps réel",
+      "Export plan de tournage gamifié",
+    ],
+    ambient: "bg-[radial-gradient(circle_at_bottom_left,rgba(236,72,153,0.25),transparent_70%)]",
+  },
+  {
+    id: "seedance",
+    title: "Seedance Pro - Choreo Engine",
+    punchline: "La danse des caméras orchestrée par l'IA.",
+    description:
+      "Seedance anticipe les mouvements, cale le rythme, propose des riffs caméra improbables. On ne perd plus un moment fort.",
+    upgrades: [
+      "Pré-visualisation motion capture",
+      "Macro Atem scriptée en live",
+      "Export plan chorégraphique pdf + audio guide",
+    ],
+    ambient: "bg-[radial-gradient(circle_at_80%_30%,rgba(16,185,129,0.25),transparent_70%)]",
+  },
+  {
+    id: "veo",
+    title: "Veo 3 - Post-production AI",
+    punchline: "Montage, colorimétrie et VFX : tout parle le même langage.",
+    description:
+      "L'IA nous aide à synchroniser les points de montage, générer des transitions, calibrer vos LUTs et sortir 9 formats en parallèle.",
+    upgrades: [
+      "Timeline multivers en un clic",
+      "Détection gag & punchline automatique",
+      "Livraison 9:16 optimisée en 30 min",
+    ],
+    ambient: "bg-[radial-gradient(circle_at_20%_80%,rgba(248,113,113,0.25),transparent_70%)]",
+  },
+];
+
+const Playground = () => {
+  const [selected, setSelected] = useState(labs[0]);
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-white">
+      <div className="pointer-events-none absolute inset-0 animate-[spin_30s_linear_infinite] bg-[conic-gradient(from_0deg,rgba(56,189,248,0.12),transparent_60%,rgba(236,72,153,0.12))]" />
+      <div className="relative mx-auto max-w-6xl px-6 pb-32 pt-28">
+        <header className="rounded-[3rem] border border-white/10 bg-white/5 p-12 shadow-[0_20px_120px_rgba(14,165,233,0.2)]">
+          <div className="flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
+            <div className="max-w-3xl space-y-6">
+              <span className="inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.35em] text-cyan-100/80">
+                Playground IA & R&D
+              </span>
+              <h1 className="text-5xl font-black leading-tight">Nos laboratoires privés pour hybrider réel & IA</h1>
+              <p className="text-lg text-slate-200/80">
+                On expérimente chaque semaine : prompts absurdes, lip-sync robotique, caméras autonomes. Résultat : des tournages ultra fluides et des idées fraîches.
+              </p>
+            </div>
+            <div className="rounded-[2.5rem] border border-white/10 bg-white/10 p-8 text-sm text-slate-200/80">
+              <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70">Mise à jour</p>
+              <p className="mt-3 text-white">Version septembre 2025 : compatibilité Suno AI 2.0 et workflow Kling 2.5 live.</p>
+            </div>
+          </div>
+        </header>
+
+        <section className="mt-16 grid gap-10 lg:grid-cols-[0.7fr_1.3fr]">
+          <div className="rounded-[2.5rem] border border-white/10 bg-white/5 p-6">
+            <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70">Choisissez votre terrain de jeu</p>
+            <div className="mt-6 grid gap-3">
+              {labs.map((lab) => (
+                <button
+                  key={lab.id}
+                  type="button"
+                  onClick={() => setSelected(lab)}
+                  className={`group relative overflow-hidden rounded-2xl border border-white/10 px-5 py-4 text-left transition-all ${
+                    selected.id === lab.id ? "border-cyan-300 bg-white/15" : "bg-white/5 hover:bg-white/10"
+                  }`}
+                >
+                  <span className="absolute inset-0 -z-10 opacity-0 transition-opacity duration-500 group-hover:opacity-100" style={{ background: "linear-gradient(120deg, rgba(56,189,248,0.25), rgba(236,72,153,0.2))" }} />
+                  <p className="text-sm font-semibold text-white">{lab.title}</p>
+                  <p className="text-xs text-slate-200/70">{lab.punchline}</p>
+                </button>
+              ))}
+            </div>
+            <div className="mt-8 rounded-2xl border border-white/10 bg-white/5 p-4 text-xs text-slate-200/70">
+              <p className="uppercase tracking-[0.3em] text-cyan-200/70">Bonus</p>
+              <p className="mt-2">Chaque expérimentation donne lieu à une mini capsule making-of envoyée à nos clients fidèles.</p>
+            </div>
+          </div>
+          <div className={`relative overflow-hidden rounded-[3rem] border border-white/10 bg-white/5 p-12 shadow-[0_20px_120px_rgba(56,189,248,0.18)] ${selected.ambient}`}>
+            <div className="relative space-y-8">
+              <div className="text-xs uppercase tracking-[0.3em] text-cyan-200/70">Lab actif</div>
+              <h2 className="text-4xl font-extrabold">{selected.title}</h2>
+              <p className="text-lg text-slate-200/80">{selected.description}</p>
+              <div className="grid gap-4 text-sm text-slate-200/80 sm:grid-cols-2">
+                {selected.upgrades.map((item) => (
+                  <div key={item} className="rounded-3xl border border-white/10 bg-white/10 p-5">
+                    <p className="flex items-center gap-3 text-xs uppercase tracking-[0.3em] text-cyan-200/70">
+                      <span className="h-2 w-2 rounded-full bg-cyan-300" /> Upgrade
+                    </p>
+                    <p className="mt-3">{item}</p>
+                  </div>
+                ))}
+              </div>
+              <div className="rounded-[2.5rem] border border-white/10 bg-white/5 p-6 text-sm text-slate-200/70">
+                <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70">Humour garanti</p>
+                <p className="mt-2">On a même un bot qui fait des blagues sur Davinci Resolve pour détendre le plateau.</p>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default Playground;

--- a/src/pages/Portfolio.tsx
+++ b/src/pages/Portfolio.tsx
@@ -1,0 +1,125 @@
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { useStudio } from "@/context/StudioContext";
+
+const Portfolio = () => {
+  const { portfolioItems } = useStudio();
+  const categories = useMemo(() => ["Tous", ...new Set(portfolioItems.map((item) => item.category))], [portfolioItems]);
+  const [filter, setFilter] = useState("Tous");
+
+  const filtered = useMemo(
+    () =>
+      filter === "Tous"
+        ? portfolioItems
+        : portfolioItems.filter((item) => item.category === filter),
+    [filter, portfolioItems],
+  );
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-white">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_10%_10%,rgba(8,145,178,0.25),transparent_60%)]" />
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_90%_90%,rgba(236,72,153,0.2),transparent_60%)]" />
+      <div className="relative mx-auto max-w-6xl px-6 pb-32 pt-28">
+        <header className="rounded-[3rem] border border-white/10 bg-white/5 p-12 shadow-[0_25px_120px_rgba(14,165,233,0.2)]">
+          <div className="flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
+            <div className="max-w-3xl space-y-6">
+              <span className="inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.35em] text-cyan-100/80">
+                Portfolio futuriste
+              </span>
+              <h1 className="text-5xl font-black leading-tight">Nos histoires préférées (pour l'instant)</h1>
+              <p className="text-lg text-slate-200/80">
+                Chaque projet est une mini-série : humour, rythme, pipelines IA, data. Ajoutez, modifiez, supprimez vos cases depuis le dashboard.
+              </p>
+            </div>
+            <div className="rounded-[2.5rem] border border-white/10 bg-white/10 p-8 text-sm text-slate-200/80">
+              <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70">Gestion autonome</p>
+              <p className="mt-3">Rendez-vous dans le dashboard pour éditer le portfolio en 3 clics.</p>
+              <Link
+                to="/dashboard"
+                className="mt-4 inline-flex items-center gap-3 rounded-full border border-cyan-200/40 bg-cyan-500/20 px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white"
+              >
+                Ouvrir le tableau de bord
+              </Link>
+            </div>
+          </div>
+        </header>
+
+        <section className="mt-16">
+          <div className="flex flex-wrap items-center gap-3">
+            {categories.map((category) => (
+              <button
+                key={category}
+                type="button"
+                onClick={() => setFilter(category)}
+                className={`rounded-full border px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] transition ${
+                  filter === category
+                    ? "border-cyan-200/60 bg-cyan-500/20 text-white"
+                    : "border-white/20 bg-white/10 text-slate-200/80 hover:bg-white/15"
+                }`}
+              >
+                {category}
+              </button>
+            ))}
+          </div>
+
+          <div className="mt-10 grid gap-8 md:grid-cols-2 xl:grid-cols-3">
+            {filtered.map((project, index) => (
+              <article
+                key={project.id}
+                className="group relative flex h-full flex-col overflow-hidden rounded-[3rem] border border-white/10 bg-gradient-to-br from-white/10 via-slate-900/40 to-slate-900/60 p-6 shadow-[0_20px_110px_rgba(56,189,248,0.15)] transition-transform duration-500 hover:-translate-y-2"
+              >
+                <span className="absolute inset-0 -z-10 opacity-0 transition-opacity duration-700 group-hover:opacity-100" style={{ background: "linear-gradient(120deg, rgba(236,72,153,0.25), rgba(59,130,246,0.2))" }} />
+                <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-slate-200/70">
+                  <span>Episode 0{index + 1}</span>
+                  <span>{project.category}</span>
+                </div>
+                <h2 className="mt-4 text-2xl font-bold text-white">{project.title}</h2>
+                <p className="mt-2 text-sm text-slate-200/80">{project.tagline}</p>
+                <div className="mt-4 flex flex-wrap gap-2 text-xs text-cyan-100/70">
+                  {project.aiTools.map((tool) => (
+                    <span key={tool} className="rounded-full bg-cyan-500/10 px-3 py-1">
+                      {tool}
+                    </span>
+                  ))}
+                </div>
+                <div className="mt-6 grid gap-3 text-xs text-slate-200/70 sm:grid-cols-3">
+                  <div className="rounded-2xl bg-white/5 p-3 text-center">{project.year}</div>
+                  <div className="rounded-2xl bg-white/5 p-3 text-center">{project.duration}</div>
+                  <div className="rounded-2xl bg-white/5 p-3 text-center">{project.socialStack.join(" · ")}</div>
+                </div>
+                <div className="mt-6 overflow-hidden rounded-[2rem] border border-white/10">
+                  <img src={project.thumbnail} alt={project.title} className="h-56 w-full object-cover object-center" />
+                </div>
+                <div className="mt-6 space-y-3 text-sm text-slate-200/80">
+                  <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70">Deliverables</p>
+                  <ul className="space-y-1">
+                    {project.deliverables.map((item) => (
+                      <li key={item} className="flex items-center gap-3">
+                        <span className="h-2 w-2 rounded-full bg-cyan-300" /> {item}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </article>
+            ))}
+          </div>
+
+          {filtered.length === 0 && (
+            <div className="mt-16 rounded-[3rem] border border-white/10 bg-white/10 p-12 text-center text-sm text-slate-200/70">
+              <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70">Filtre un peu trop spécifique</p>
+              <p className="mt-4 text-2xl text-white">Ajoutez un nouveau projet depuis le dashboard pour remplir cette catégorie.</p>
+              <Link
+                to="/dashboard"
+                className="mt-6 inline-flex items-center gap-3 rounded-full border border-cyan-200/40 bg-cyan-500/20 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white"
+              >
+                Ajouter un projet
+              </Link>
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default Portfolio;

--- a/src/pages/Process.tsx
+++ b/src/pages/Process.tsx
@@ -1,0 +1,94 @@
+const timeline = [
+  {
+    id: "brief",
+    title: "Brief cosmique",
+    description:
+      "On décode votre univers, vos objectifs, vos inside jokes. Notre IA résume, priorise et propose des premières punchlines.",
+    vibe: "bg-[radial-gradient(circle_at_top,rgba(14,165,233,0.25),transparent_70%)]",
+  },
+  {
+    id: "design",
+    title: "Design narratif",
+    description:
+      "Moodboards Midjourney V7, script génératif, découpage shotlist. Chaque scène a son hook, son moment humour, son CTA.",
+    vibe: "bg-[radial-gradient(circle_at_60%_20%,rgba(236,72,153,0.25),transparent_70%)]",
+  },
+  {
+    id: "shoot",
+    title: "Tournage chorégraphié",
+    description:
+      "Seedance Pro prédit les mouvements, Kling 2.5 projette les décors, nos équipes rigolent mais restent focus.",
+    vibe: "bg-[radial-gradient(circle_at_30%_80%,rgba(249,115,22,0.2),transparent_70%)]",
+  },
+  {
+    id: "post",
+    title: "Post-prod synchrone",
+    description:
+      "Veo 3 accélère le montage, Davinci peaufine, Suno AI livre le sound design, LypSync V2 anime les punchlines.",
+    vibe: "bg-[radial-gradient(circle_at_bottom_right,rgba(94,234,212,0.2),transparent_70%)]",
+  },
+  {
+    id: "launch",
+    title: "Launch orchestré",
+    description:
+      "On publie, on tracke, on ajuste. Les memes partent, les stats montent, le chat se remplit de gifs heureux.",
+    vibe: "bg-[radial-gradient(circle_at_50%_50%,rgba(129,140,248,0.25),transparent_70%)]",
+  },
+];
+
+const Process = () => {
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-white">
+      <div className="pointer-events-none absolute inset-0 bg-[conic-gradient(from_60deg_at_50%_50%,rgba(8,145,178,0.2),transparent_70%)]" />
+      <div className="relative mx-auto max-w-6xl px-6 pb-32 pt-28">
+        <header className="rounded-[3rem] border border-white/10 bg-white/5 p-12 shadow-[0_20px_120px_rgba(14,165,233,0.2)]">
+          <div className="space-y-6">
+            <span className="inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.35em] text-cyan-100/80">
+              Processus Studio VBG
+            </span>
+            <h1 className="text-5xl font-black leading-tight">La méthode orbitale qui fait sourire vos KPI</h1>
+            <p className="text-lg text-slate-200/80">
+              Des micro-hooks en pré-prod aux chats post-devis, chaque étape est calibrée. On mélange IA, rigueur, humour et dashboards.
+            </p>
+          </div>
+        </header>
+
+        <section className="mt-16 space-y-12">
+          {timeline.map((step, index) => (
+            <article
+              key={step.id}
+              className={`relative overflow-hidden rounded-[3rem] border border-white/10 bg-white/5 p-10 shadow-[0_20px_110px_rgba(56,189,248,0.15)] ${step.vibe}`}
+            >
+              <span className="absolute left-12 top-8 text-6xl font-black text-white/10">0{index + 1}</span>
+              <div className="relative grid gap-6 lg:grid-cols-[1.2fr_1fr]">
+                <div className="space-y-4">
+                  <h2 className="text-3xl font-extrabold">{step.title}</h2>
+                  <p className="text-lg text-slate-200/80">{step.description}</p>
+                </div>
+                <div className="rounded-[2.5rem] border border-white/10 bg-white/10 p-6 text-sm text-slate-200/70">
+                  <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70">Ce qui se passe réellement</p>
+                  <p className="mt-3">
+                    {index === 0 && "Notre IA résume les 14 slides reçues, extrait les insights et propose 3 hooks."}
+                    {index === 1 && "On produit des scripts comiques, des visuels 3D et un plan d'attaque social média."}
+                    {index === 2 && "Plateau modulable, robots, macros Atem, humour pour détendre le client."}
+                    {index === 3 && "Montage collaboratif, exports multiples, automatisation sous Notion & Zapier."}
+                    {index === 4 && "On livre, on tracke, on envoie un meme de célébration sur le chat de suivi."}
+                  </p>
+                </div>
+              </div>
+            </article>
+          ))}
+        </section>
+
+        <section className="mt-16 rounded-[3rem] border border-white/10 bg-white/5 p-12 text-center text-sm text-slate-200/70">
+          <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70">Prêt·e à rejoindre l'orbite ?</p>
+          <p className="mt-6 text-3xl font-semibold text-white">
+            Connectez-vous, briefez-nous, on déclenche le mode hyperdrive de Studio VBG.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default Process;

--- a/src/pages/QuoteBuilder.tsx
+++ b/src/pages/QuoteBuilder.tsx
@@ -1,0 +1,211 @@
+import { FormEvent, useState } from "react";
+import { Link } from "react-router-dom";
+import { useStudio } from "@/context/StudioContext";
+
+const availableServices = [
+  "Captation multicam",
+  "IA scénarisation",
+  "Plateau XR",
+  "Pack réseaux",
+  "Live event",
+  "Memes corporate",
+];
+
+const QuoteBuilder = () => {
+  const { user, createQuoteRequest } = useStudio();
+  const [step, setStep] = useState(0);
+  const [successId, setSuccessId] = useState<string | null>(null);
+  const [form, setForm] = useState({
+    projectName: "",
+    budgetRange: "",
+    deadline: "",
+    services: [] as string[],
+    moodboardPrompt: "",
+  });
+
+  if (!user) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center bg-slate-950 px-6 text-center text-white">
+        <div className="max-w-xl space-y-6 rounded-[3rem] border border-white/10 bg-white/5 p-12">
+          <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70">Étape obligatoire</p>
+          <h1 className="text-4xl font-black leading-tight">Connectez-vous avant de demander un devis</h1>
+          <p className="text-lg text-slate-200/80">
+            Le devis débloque ensuite un chat temps réel avec nos équipes. Créons votre cockpit.
+          </p>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link to="/auth" className="rounded-full border border-cyan-200/40 bg-cyan-500/20 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white">
+              Me connecter
+            </Link>
+            <Link to="/" className="rounded-full border border-white/30 bg-white/10 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white">
+              Explorer avant
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const quote = createQuoteRequest(form);
+    if (quote) {
+      setSuccessId(quote.id);
+    }
+  };
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-white">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_15%_15%,rgba(14,165,233,0.2),transparent_60%)]" />
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_85%_85%,rgba(236,72,153,0.2),transparent_60%)]" />
+      <div className="relative mx-auto max-w-5xl px-6 pb-32 pt-28">
+        <header className="rounded-[3rem] border border-white/10 bg-white/5 p-12 shadow-[0_20px_120px_rgba(14,165,233,0.2)]">
+          <div className="flex flex-col gap-6">
+            <span className="inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.35em] text-cyan-100/80">
+              Demande de devis · Studio VBG
+            </span>
+            <h1 className="text-5xl font-black leading-tight">Construisons votre mission vidéo</h1>
+            <p className="text-lg text-slate-200/80">
+              3 étapes fluides, un brin d'humour et notre IA qui synthétise tout pour l'équipe de prod.
+            </p>
+          </div>
+        </header>
+
+        <form onSubmit={handleSubmit} className="mt-16 space-y-8 rounded-[3rem] border border-white/10 bg-white/10 p-10 shadow-[0_20px_100px_rgba(236,72,153,0.2)]">
+          <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-slate-200/70">
+            <span>Étape {step + 1} / 3</span>
+            <div className="flex gap-2">
+              {[0, 1, 2].map((index) => (
+                <span
+                  key={index}
+                  className={`h-1.5 w-16 rounded-full ${index <= step ? "bg-cyan-300" : "bg-white/20"}`}
+                />
+              ))}
+            </div>
+          </div>
+
+          {step === 0 && (
+            <div className="space-y-4">
+              <div>
+                <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Nom de mission</label>
+                <input
+                  className="mt-2 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:border-cyan-400 focus:outline-none"
+                  value={form.projectName}
+                  onChange={(event) => setForm((prev) => ({ ...prev, projectName: event.target.value }))}
+                  placeholder="Lancement casque quantique"
+                  required
+                />
+              </div>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div>
+                  <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Budget pressenti</label>
+                  <input
+                    className="mt-2 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:border-cyan-400 focus:outline-none"
+                    value={form.budgetRange}
+                    onChange={(event) => setForm((prev) => ({ ...prev, budgetRange: event.target.value }))}
+                    placeholder="15k€ - 25k€"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Deadline</label>
+                  <input
+                    type="date"
+                    className="mt-2 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:border-cyan-400 focus:outline-none"
+                    value={form.deadline}
+                    onChange={(event) => setForm((prev) => ({ ...prev, deadline: event.target.value }))}
+                    required
+                  />
+                </div>
+              </div>
+            </div>
+          )}
+
+          {step === 1 && (
+            <div className="space-y-4">
+              <p className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Services souhaités</p>
+              <div className="grid gap-3 sm:grid-cols-2">
+                {availableServices.map((service) => {
+                  const active = form.services.includes(service);
+                  return (
+                    <button
+                      key={service}
+                      type="button"
+                      onClick={() =>
+                        setForm((prev) => ({
+                          ...prev,
+                          services: active
+                            ? prev.services.filter((item) => item !== service)
+                            : [...prev.services, service],
+                        }))
+                      }
+                      className={`rounded-2xl border px-4 py-3 text-left text-sm transition ${
+                        active ? "border-cyan-300 bg-white/20 text-white" : "border-white/20 bg-white/10 text-slate-200/80"
+                      }`}
+                    >
+                      {service}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {step === 2 && (
+            <div className="space-y-4">
+              <div>
+                <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Moodboard & intentions</label>
+                <textarea
+                  className="mt-2 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:border-cyan-400 focus:outline-none"
+                  rows={6}
+                  value={form.moodboardPrompt}
+                  onChange={(event) => setForm((prev) => ({ ...prev, moodboardPrompt: event.target.value }))}
+                  placeholder="Imagine un plan-séquence dans une serre néon, le CEO se téléporte, un bot Suno chante."
+                  required
+                />
+              </div>
+              <p className="text-xs text-slate-200/60">
+                Notre IA transforme ce prompt en storyboard, playlist audio et planning.
+              </p>
+            </div>
+          )}
+
+          <div className="flex justify-between pt-4">
+            <button
+              type="button"
+              onClick={() => setStep((prev) => Math.max(prev - 1, 0))}
+              className="rounded-full border border-white/30 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white disabled:opacity-40"
+              disabled={step === 0}
+            >
+              Retour
+            </button>
+            {step < 2 ? (
+              <button
+                type="button"
+                onClick={() => setStep((prev) => Math.min(prev + 1, 2))}
+                className="rounded-full border border-cyan-200/40 bg-cyan-500/20 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white"
+              >
+                Étape suivante
+              </button>
+            ) : (
+              <button
+                type="submit"
+                className="group relative overflow-hidden rounded-full border border-cyan-200/40 bg-cyan-500/20 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white"
+              >
+                <span className="relative z-10">Envoyer le brief</span>
+                <span className="absolute inset-0 translate-x-[-120%] bg-gradient-to-r from-cyan-400 via-sky-300 to-fuchsia-400 transition-transform duration-700 group-hover:translate-x-0" />
+              </button>
+            )}
+          </div>
+
+          {successId && (
+            <div className="rounded-3xl border border-emerald-200/40 bg-emerald-500/10 p-6 text-sm text-emerald-100">
+              Votre demande est bien arrivée ! On ouvre un chat dédié dès validation du devis. ID : {successId.slice(0, 8)}...
+            </div>
+          )}
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default QuoteBuilder;

--- a/src/pages/ServiceDetail.tsx
+++ b/src/pages/ServiceDetail.tsx
@@ -1,0 +1,108 @@
+import { Link, useParams } from "react-router-dom";
+import { servicesData } from "@/lib/services";
+
+const ServiceDetail = () => {
+  const { slug } = useParams();
+  const service = servicesData.find((item) => item.slug === slug);
+
+  if (!service) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center bg-slate-950 text-white">
+        <p className="text-sm uppercase tracking-[0.3em] text-cyan-200/70">Service introuvable</p>
+        <h1 className="mt-4 text-4xl font-bold">On dirait que ce module est encore en R&D.</h1>
+        <Link to="/services" className="mt-8 rounded-full border border-cyan-200/40 bg-cyan-500/20 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white">
+          Retour aux services
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-white">
+      <div className="pointer-events-none absolute inset-0 bg-[conic-gradient(from_120deg_at_20%_20%,rgba(6,182,212,0.25),rgba(236,72,153,0.15),transparent_70%)]" />
+      <div className="relative mx-auto max-w-6xl px-6 pb-24 pt-28">
+        <header className="rounded-[3rem] border border-white/10 bg-white/5 p-12 shadow-[0_20px_120px_rgba(34,211,238,0.2)]">
+          <div className="flex flex-col gap-10 lg:flex-row lg:items-end lg:justify-between">
+            <div className="space-y-6">
+              <span className="inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.35em] text-cyan-100/80">
+                Module Studio VBG
+              </span>
+              <h1 className="text-5xl font-black">{service.title}</h1>
+              <p className="text-lg text-slate-200/80">{service.subtitle}</p>
+            </div>
+            <div className="text-sm text-slate-200/70">
+              <p className="uppercase tracking-[0.3em] text-cyan-200/80">Signature move</p>
+              <p className="mt-2 text-lg text-white">{service.signatureMove}</p>
+            </div>
+          </div>
+        </header>
+
+        <section className="mt-16 grid gap-12 lg:grid-cols-[1.5fr_1fr]">
+          <div className="space-y-10">
+            <div className="rounded-[2.5rem] border border-white/10 bg-white/5 p-10 shadow-[0_15px_80px_rgba(14,165,233,0.2)]">
+              <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70">Narration</p>
+              <p className="mt-4 text-lg leading-relaxed text-slate-200/80">{service.promise}</p>
+            </div>
+            <div className="space-y-6">
+              {service.phases.map((phase, index) => (
+                <div
+                  key={phase.title}
+                  className="group relative overflow-hidden rounded-[2.5rem] border border-white/10 bg-gradient-to-br from-white/10 to-white/5 p-8 shadow-[0_20px_90px_rgba(236,72,153,0.18)]"
+                >
+                  <span className="absolute inset-0 translate-y-full bg-gradient-to-t from-fuchsia-500/20 via-transparent to-transparent transition-transform duration-700 group-hover:translate-y-0" />
+                  <div className="relative space-y-4">
+                    <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-slate-200/70">
+                      <span>Phase 0{index + 1}</span>
+                      <span>{phase.aiUpgrade}</span>
+                    </div>
+                    <h2 className="text-2xl font-bold">{phase.title}</h2>
+                    <p className="text-sm text-slate-200/80">{phase.description}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+          <aside className="space-y-8">
+            <div className="rounded-[2.5rem] border border-white/10 bg-white/5 p-8">
+              <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70">Livrables inclus</p>
+              <ul className="mt-4 space-y-3 text-sm text-slate-200/80">
+                {service.deliverables.map((item) => (
+                  <li key={item} className="flex items-start gap-3">
+                    <span className="mt-1 h-2 w-2 rounded-full bg-cyan-300" />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div className="rounded-[2.5rem] border border-white/10 bg-white/5 p-8">
+              <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70">Chiffres clés</p>
+              <ul className="mt-4 space-y-4 text-sm text-slate-200/80">
+                {service.metrics.map((metric) => (
+                  <li key={metric.label} className="rounded-2xl bg-slate-900/60 p-4">
+                    <p className="text-xs uppercase tracking-[0.3em] text-slate-200/60">{metric.label}</p>
+                    <p className="mt-2 text-2xl font-bold text-cyan-200">{metric.value}</p>
+                    <p className="text-xs text-slate-200/60">{metric.note}</p>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div className="rounded-[2.5rem] border border-white/10 bg-white/5 p-8 text-sm text-slate-200/80">
+              <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70">Prochain move</p>
+              <p className="mt-4">Prêt·e à valider ce module ? Connectez-vous, demandez un devis et on lance la pré-production.</p>
+              <div className="mt-6 flex flex-col gap-3">
+                <Link to="/auth" className="rounded-full border border-white/30 bg-white/10 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white">
+                  Me connecter
+                </Link>
+                <Link to="/quote" className="rounded-full border border-cyan-200/40 bg-cyan-500/20 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white">
+                  Demander un devis
+                </Link>
+              </div>
+            </div>
+          </aside>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default ServiceDetail;

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -1,0 +1,129 @@
+import { Link } from "react-router-dom";
+import { servicesData } from "@/lib/services";
+
+const Services = () => {
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-white">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_10%_20%,rgba(8,145,178,0.35),transparent_60%)]" />
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_80%_80%,rgba(236,72,153,0.25),transparent_60%)]" />
+      <div className="relative mx-auto flex max-w-6xl flex-col gap-16 px-6 pb-32 pt-32">
+        <header className="rounded-[3rem] border border-white/10 bg-white/5 p-12 shadow-[0_25px_120px_rgba(14,165,233,0.2)]">
+          <div className="flex flex-col gap-10 lg:flex-row lg:items-center lg:justify-between">
+            <div className="max-w-3xl space-y-6">
+              <span className="inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.35em] text-cyan-100/80">
+                Services Studio VBG · 2025
+              </span>
+              <h1 className="text-5xl font-black leading-tight">
+                Trois modules interstellaires pour propulser vos contenus vidéo
+              </h1>
+              <p className="text-lg text-slate-200/80">
+                Chaque service est pensé comme un épisode de série premium : intro explosive, développement punchy, final qui fait cliquer.
+                On combine plateau réel, IA générative et humour bien dosé.
+              </p>
+            </div>
+            <div className="grid gap-4 text-sm text-slate-200/70">
+              <div className="rounded-3xl border border-white/10 bg-white/10 p-5">
+                <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70">Synergie stack</p>
+                <p className="mt-2">Midjourney V7 · Kling 2.5 · Seedance Pro · Veo 3 · Suno AI · LypSync V2</p>
+              </div>
+              <div className="rounded-3xl border border-white/10 bg-white/10 p-5">
+                <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70">Petit plus</p>
+                <p className="mt-2">Chaque module inclut un icebreaker comique avec votre équipe.</p>
+              </div>
+            </div>
+          </div>
+        </header>
+
+        <section className="grid gap-12">
+          {servicesData.map((service, index) => (
+            <article
+              key={service.slug}
+              className="relative overflow-hidden rounded-[3rem] border border-white/10 bg-gradient-to-br from-white/10 via-slate-900/40 to-slate-900/60 p-12 shadow-[0_20px_120px_rgba(59,130,246,0.18)]"
+            >
+              <span className="absolute inset-0 translate-x-[-100%] bg-gradient-to-r from-cyan-500/20 via-transparent to-transparent opacity-0 transition-all duration-700 hover:translate-x-0 hover:opacity-100" />
+              <div className="relative grid gap-8 lg:grid-cols-[1.5fr_1fr]">
+                <div className="space-y-6">
+                  <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-slate-200/70">
+                    <span>Module 0{index + 1}</span>
+                    <span>{service.signatureMove}</span>
+                  </div>
+                  <h2 className="text-4xl font-extrabold">{service.title}</h2>
+                  <p className="text-lg text-slate-200/80">{service.subtitle}</p>
+                  <div className="grid gap-4 text-sm text-slate-200/80 lg:grid-cols-2">
+                    <div className="rounded-3xl border border-white/10 bg-white/10 p-5">
+                      <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70">Problème</p>
+                      <p className="mt-2 leading-relaxed">{service.problem}</p>
+                    </div>
+                    <div className="rounded-3xl border border-white/10 bg-white/10 p-5">
+                      <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70">Promesse</p>
+                      <p className="mt-2 leading-relaxed">{service.promise}</p>
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap gap-3 text-xs uppercase tracking-[0.3em] text-cyan-100/80">
+                    {service.stack.map((tool) => (
+                      <span key={tool} className="rounded-full border border-cyan-200/30 bg-cyan-500/10 px-4 py-2">
+                        {tool}
+                      </span>
+                    ))}
+                  </div>
+                  <Link
+                    to={`/services/${service.slug}`}
+                    className="inline-flex items-center gap-3 rounded-full border border-white/20 bg-white/10 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white transition hover:bg-white/20"
+                  >
+                    Découvrir les coulisses
+                  </Link>
+                </div>
+                <div className="space-y-6">
+                  <div className="rounded-3xl border border-white/10 bg-white/10 p-6">
+                    <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70">Livrables</p>
+                    <ul className="mt-4 space-y-2 text-sm text-slate-200/80">
+                      {service.deliverables.map((item) => (
+                        <li key={item} className="flex items-center gap-3">
+                          <span className="h-2 w-2 rounded-full bg-cyan-300" /> {item}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                  <div className="rounded-3xl border border-white/10 bg-white/10 p-6">
+                    <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70">Chiffres clés</p>
+                    <ul className="mt-4 space-y-3 text-sm text-slate-200/80">
+                      {service.metrics.map((metric) => (
+                        <li key={metric.label} className="flex items-center justify-between rounded-2xl bg-slate-900/60 px-4 py-3">
+                          <span>{metric.label}</span>
+                          <span className="text-cyan-200">{metric.value}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+              </div>
+            </article>
+          ))}
+        </section>
+
+        <section className="rounded-[3rem] border border-white/10 bg-white/5 p-12 text-center text-sm text-slate-200/70">
+          <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70">Envie d'un mix personnalisé ?</p>
+          <p className="mt-6 text-3xl font-semibold text-white">
+            On assemble un module sur-mesure en mixant nos services, on y ajoute une pincée d'IA et une blague bien placée.
+          </p>
+          <div className="mt-8 flex flex-wrap justify-center gap-4">
+            <Link
+              to="/quote"
+              className="rounded-full border border-cyan-200/30 bg-cyan-500/20 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white"
+            >
+              Je veux un devis futuriste
+            </Link>
+            <Link
+              to="/auth"
+              className="rounded-full border border-white/30 bg-white/10 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white"
+            >
+              Me connecter avant de briefer
+            </Link>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default Services;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
 
 export default {
   darkMode: ["class"],
@@ -87,5 +88,5 @@ export default {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [animatePlugin],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add a StudioProvider data layer with navigation enhancements to drive authentication, portfolio and quote state across the app
- replace the landing page and craft new services, playground, portfolio and process pages with futuristic storytelling and interactions
- gate the quote builder behind login and deliver a full dashboard to manage accounts, portfolio items, pricing, quotes and chat threads

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d49fa80124832892b62a2e86ccb317