### PR TITLE
Refine wording across site to professional tone

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "sonner": "^1.7.4",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
+        "uuid": "^13.0.0",
         "vaul": "^0.9.9",
         "zod": "^3.25.76"
       },
@@ -6519,6 +6520,19 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
     },
     "node_modules/vaul": {
       "version": "0.9.9",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "sonner": "^1.7.4",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
+    "uuid": "^13.0.0",
     "vaul": "^0.9.9",
     "zod": "^3.25.76"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,17 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import Services from "./pages/Services";
+import ServiceDetail from "./pages/ServiceDetail";
+import Playground from "./pages/Playground";
+import Portfolio from "./pages/Portfolio";
+import Process from "./pages/Process";
+import QuoteBuilder from "./pages/QuoteBuilder";
+import Auth from "./pages/Auth";
+import Dashboard from "./pages/Dashboard";
+import { StudioProvider } from "./context/StudioContext";
+import { WaveMenu } from "./components/WaveMenu";
+import { ProtectedRoute } from "./components/ProtectedRoute";
 
 const queryClient = new QueryClient();
 
@@ -13,13 +24,31 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Index />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
+      <StudioProvider>
+        <BrowserRouter>
+          <WaveMenu />
+          <Routes>
+            <Route path="/" element={<Index />} />
+            <Route path="/services" element={<Services />} />
+            <Route path="/services/:slug" element={<ServiceDetail />} />
+            <Route path="/playground" element={<Playground />} />
+            <Route path="/portfolio" element={<Portfolio />} />
+            <Route path="/process" element={<Process />} />
+            <Route path="/quote" element={<QuoteBuilder />} />
+            <Route path="/auth" element={<Auth />} />
+            <Route
+              path="/dashboard"
+              element={(
+                <ProtectedRoute requireAdmin>
+                  <Dashboard />
+                </ProtectedRoute>
+              )}
+            />
+            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </BrowserRouter>
+      </StudioProvider>
     </TooltipProvider>
   </QueryClientProvider>
 );

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,20 @@
+import { ReactNode } from "react";
+import { Navigate, useLocation } from "react-router-dom";
+import { useStudio } from "@/context/StudioContext";
+
+const ADMIN_EMAIL = "volberg.thomas@gmail.com";
+
+export const ProtectedRoute = ({ children, requireAdmin = false }: { children: ReactNode; requireAdmin?: boolean }) => {
+  const { user } = useStudio();
+  const location = useLocation();
+
+  if (!user) {
+    return <Navigate to="/auth" state={{ from: location.pathname }} replace />;
+  }
+
+  if (requireAdmin && user.email !== ADMIN_EMAIL) {
+    return <Navigate to="/" replace />;
+  }
+
+  return <>{children}</>;
+};

--- a/src/components/WaveMenu.tsx
+++ b/src/components/WaveMenu.tsx
@@ -1,0 +1,99 @@
+import { useState } from "react";
+import { Link, useLocation } from "react-router-dom";
+import { navigationItems } from "@/lib/navigation";
+import { cn } from "@/lib/utils";
+import { useStudio } from "@/context/StudioContext";
+
+export const WaveMenu = () => {
+  const [expanded, setExpanded] = useState(true);
+  const location = useLocation();
+  const { visualMode, cycleVisualMode, palette } = useStudio();
+
+  return (
+    <>
+      <div className="pointer-events-none fixed right-2 top-0 z-50 hidden h-screen lg:flex">
+        <div className="pointer-events-auto flex h-full flex-col justify-center gap-4">
+          <button
+            type="button"
+            onClick={() => setExpanded((prev) => !prev)}
+            className="group relative overflow-hidden rounded-full border border-white/20 bg-slate-900/60 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white shadow-[0_0_30px_rgba(0,0,0,0.5)] backdrop-blur transition hover:bg-slate-900/80"
+          >
+            <span className="relative inline-flex items-center gap-2">
+              <span className="h-2 w-2 rounded-full bg-emerald-400 shadow-[0_0_10px_rgba(16,185,129,0.8)]" />
+              {expanded ? "Mode vague" : "Menu"}
+            </span>
+            <span className="absolute inset-0 animate-[pulse_2s_infinite] bg-gradient-to-r from-emerald-400/40 via-transparent to-cyan-500/40 opacity-0 transition group-hover:opacity-100" />
+          </button>
+          <button
+            type="button"
+            onClick={cycleVisualMode}
+            className="group relative overflow-hidden rounded-full border border-cyan-200/40 visual-accent-border bg-cyan-500/20 visual-accent-bg px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-cyan-100 visual-accent-text shadow-[0_10px_30px_rgba(8,145,178,0.25)] visual-accent-shadow transition hover:scale-105"
+          >
+            <span className="relative z-10 flex items-center gap-2">
+              <span
+                className="h-2.5 w-2.5 rounded-full shadow-[0_0_12px_rgba(255,255,255,0.35)]"
+                style={{ background: `hsl(${palette.accent})` }}
+              />
+              {visualMode === "nebula" ? "Palette Solstice" : "Palette Nébula"}
+            </span>
+            <span className="absolute inset-0 -z-10 translate-x-[-120%] bg-gradient-to-r from-cyan-400 via-sky-300 to-fuchsia-400 visual-accent-gradient transition-transform duration-700 group-hover:translate-x-0" />
+          </button>
+          <nav
+            aria-label="Menu nébuleux"
+            className={cn(
+              "relative flex w-72 origin-right flex-col gap-3 rounded-l-3xl border border-white/10 bg-gradient-to-b from-slate-950/80 via-slate-900/70 to-slate-950/80 p-4 text-sm text-white shadow-[0_0_60px_rgba(14,165,233,0.35)] transition-all duration-700",
+              expanded ? "translate-x-0 opacity-100" : "translate-x-28 opacity-0"
+            )}
+          >
+            <div className="pointer-events-none absolute -right-[60px] top-0 h-full w-[120px] overflow-hidden">
+              <div
+                className="absolute inset-0 blur-3xl"
+                style={{ background: "radial-gradient(circle at 30% 50%, hsla(var(--visual-accent)/0.7), transparent 60%)" }}
+              />
+            </div>
+            {navigationItems.map((item) => {
+              const active = location.pathname === item.to || location.pathname.startsWith(`${item.to}/`);
+              return (
+                <Link
+                  key={item.to}
+                  to={item.to}
+                  className={cn(
+                    "group relative flex items-center justify-between overflow-hidden rounded-2xl border border-white/10 px-4 py-3 transition-all",
+                    "hover:border-cyan-400/80 hover:bg-white/10 hover:text-white",
+                    active ? "border-cyan-300 bg-white/20 text-white shadow-[0_0_30px_rgba(34,211,238,0.45)]" : "text-slate-200"
+                  )}
+                >
+                  <div className="flex items-center gap-3">
+                    <span className="text-xl">{item.emoji}</span>
+                    <div>
+                      <p className="text-base font-semibold uppercase tracking-[0.2em]">{item.label}</p>
+                      <p className="text-[0.7rem] text-slate-300/80">{item.tooltip}</p>
+                    </div>
+                  </div>
+                  <span className="text-xs font-mono text-cyan-300">{active ? "ON" : ".."}</span>
+                  <span
+                    className="absolute inset-0 -z-10 translate-x-[-80%] transition-transform duration-700 group-hover:translate-x-0"
+                    style={{ background: "radial-gradient(circle at right, hsla(var(--visual-accent)/0.45), transparent 60%)" }}
+                  />
+                </Link>
+              );
+            })}
+          </nav>
+        </div>
+      </div>
+      <div className="fixed bottom-4 right-4 z-50 pointer-events-none lg:hidden">
+        <button
+          type="button"
+          onClick={cycleVisualMode}
+          className="pointer-events-auto flex items-center gap-2 rounded-full border border-cyan-200/40 visual-accent-border bg-cyan-500/20 visual-accent-bg px-4 py-2 text-xs font-semibold uppercase tracking-[0.25em] text-cyan-100 visual-accent-text shadow-[0_10px_30px_rgba(8,145,178,0.25)] visual-accent-shadow backdrop-blur"
+        >
+          <span
+            className="h-2.5 w-2.5 rounded-full shadow-[0_0_12px_rgba(255,255,255,0.35)]"
+            style={{ background: `hsl(${palette.accent})` }}
+          />
+          {visualMode === "nebula" ? "Solstice" : "Nébula"}
+        </button>
+      </div>
+    </>
+  );
+};

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => {
   return (

--- a/src/context/StudioContext.tsx
+++ b/src/context/StudioContext.tsx
@@ -1,0 +1,543 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+import { v4 as uuid } from "uuid";
+
+// Local helper to generate shimmering gradient placeholders
+const gradientPool = [
+  "from-[#61f4de] via-[#2471d6] to-[#290a5c]",
+  "from-[#fd7bff] via-[#4d31ff] to-[#120248]",
+  "from-[#ffdc63] via-[#ff7a18] to-[#45108a]",
+  "from-[#5dff9d] via-[#19b6ff] to-[#5916e1]",
+  "from-[#ff9cc6] via-[#ff6c6c] to-[#2f2aa0]",
+];
+
+export type PortfolioItem = {
+  id: string;
+  title: string;
+  tagline: string;
+  category: string;
+  year: number;
+  duration: string;
+  description: string;
+  thumbnail: string;
+  videoUrl: string;
+  gradient: string;
+  aiTools: string[];
+  deliverables: string[];
+  socialStack: string[];
+};
+
+export type PricingTier = {
+  id: string;
+  name: string;
+  price: number;
+  description: string;
+  deliverables: string[];
+  sla: string;
+};
+
+export type QuoteRequest = {
+  id: string;
+  clientId: string;
+  clientName: string;
+  projectName: string;
+  budgetRange: string;
+  deadline: string;
+  services: string[];
+  status: "nouveau" | "en revue" | "validé" | "refusé";
+  moodboardPrompt: string;
+  createdAt: string;
+};
+
+export type ChatMessage = {
+  id: string;
+  from: "studio" | "client";
+  content: string;
+  timestamp: string;
+};
+
+export type ChatThread = {
+  quoteId: string;
+  clientName: string;
+  projectName: string;
+  messages: ChatMessage[];
+};
+
+export type ContactRequest = {
+  id: string;
+  name: string;
+  email: string;
+  projectSpark: string;
+  urgency: "hier" | "cette-semaine" | "quand-c-est-parfait";
+  createdAt: string;
+};
+
+export type ClientAccount = {
+  id: string;
+  name: string;
+  email: string;
+  password: string;
+  company: string;
+  industry: string;
+  membership: "Impulse" | "Hyperdrive" | "Continuum";
+  avatarHue: number;
+  lastProject?: string;
+};
+
+type VisualMode = "nebula" | "solstice";
+
+type VisualPalette = {
+  accent: string;
+  accentSoft: string;
+  secondary: string;
+  tertiary: string;
+  accentForeground: string;
+  border: string;
+};
+
+const SERVICE_CATEGORIES = [
+  "Entreprise",
+  "Événementiel",
+  "Immobilier",
+  "Réseaux sociaux",
+  "Mariage",
+  "Motion design / IA",
+] as const;
+
+type StudioContextValue = {
+  user: ClientAccount | null;
+  clients: ClientAccount[];
+  portfolioItems: PortfolioItem[];
+  pricingTiers: PricingTier[];
+  quoteRequests: QuoteRequest[];
+  contactRequests: ContactRequest[];
+  chats: ChatThread[];
+  serviceCategories: typeof SERVICE_CATEGORIES;
+  visualMode: VisualMode;
+  palette: VisualPalette;
+  cycleVisualMode: () => void;
+  register: (payload: Omit<ClientAccount, "id" | "avatarHue">) => { success: boolean; message?: string };
+  login: (email: string, password: string) => { success: boolean; message?: string };
+  logout: () => void;
+  addPortfolioItem: (payload: Omit<PortfolioItem, "id" | "gradient"> & { gradient?: string }) => void;
+  updatePortfolioItem: (id: string, updates: Partial<PortfolioItem>) => void;
+  removePortfolioItem: (id: string) => void;
+  updatePricingTier: (id: string, updates: Partial<PricingTier>) => void;
+  createQuoteRequest: (payload: Omit<QuoteRequest, "id" | "status" | "createdAt" | "clientId" | "clientName">) => QuoteRequest | null;
+  advanceQuoteStatus: (id: string, status: QuoteRequest["status"]) => void;
+  appendChatMessage: (quoteId: string, message: Omit<ChatMessage, "id" | "timestamp">) => void;
+  recordContactRequest: (payload: Omit<ContactRequest, "id" | "createdAt">) => void;
+};
+
+const StudioContext = createContext<StudioContextValue | undefined>(undefined);
+
+const visualPalettes: Record<VisualMode, VisualPalette> = {
+  nebula: {
+    accent: "188 86% 64%",
+    accentSoft: "196 90% 78%",
+    secondary: "315 86% 66%",
+    tertiary: "251 96% 72%",
+    accentForeground: "190 100% 92%",
+    border: "188 86% 64%",
+  },
+  solstice: {
+    accent: "34 97% 62%",
+    accentSoft: "17 94% 64%",
+    secondary: "296 76% 72%",
+    tertiary: "208 88% 70%",
+    accentForeground: "35 100% 92%",
+    border: "34 97% 62%",
+  },
+};
+
+const initialPortfolio: PortfolioItem[] = [
+  {
+    id: uuid(),
+    title: "Pulse HoloBoard · Lancement corporate QuantumLoop",
+    tagline: "Accompagnement de 12 000 collaborateurs avec un dispositif immersif",
+    category: SERVICE_CATEGORIES[0],
+    year: 2025,
+    duration: "01:32",
+    description:
+      "Film d'entreprise réalisé sur plateau robotisé avec incrustations temps réel Kling 2.5. Script co-écrit avec notre IA rédactionnelle pour rendre accessible la transformation digitale et déclinaisons dédiées aux équipes internes.",
+    thumbnail: "https://images.unsplash.com/photo-1522199992901-41860af3a7f3?q=80&w=1200",
+    videoUrl: "https://www.youtube.com/watch?v=s6zR2T9vn2c",
+    gradient: gradientPool[0],
+    aiTools: ["Midjourney V7", "Kling 2.5", "DaVinci Resolve"],
+    deliverables: ["Film principal 16:9", "Version onboarding 9:16", "Kit de présentation interne"],
+    socialStack: ["Intranet", "LinkedIn", "YouTube"],
+  },
+  {
+    id: uuid(),
+    title: "Aftermovie NeoSolar · Festival IA & lumière",
+    tagline: "Aftermovie immersif pour un festival dédié à l'innovation lumineuse",
+    category: SERVICE_CATEGORIES[1],
+    year: 2024,
+    duration: "02:08",
+    description:
+      "Captation événementielle associant drones FPV, Seedance Pro pour anticiper les mouvements de foule et montage synchronisé Suno AI. Objectif : donner envie de s'inscrire dès l'ouverture de la prochaine édition.",
+    thumbnail: "https://images.unsplash.com/photo-1514525253161-7a46d19cd819?q=80&w=1200",
+    videoUrl: "https://www.youtube.com/watch?v=aqz-KE-bpKQ",
+    gradient: gradientPool[1],
+    aiTools: ["Seedance Pro", "Suno AI", "DaVinci Resolve"],
+    deliverables: ["Aftermovie 4K", "Teaser 30s", "Stories pré-event"],
+    socialStack: ["Instagram", "TikTok", "YouTube Shorts"],
+  },
+  {
+    id: uuid(),
+    title: "Skyline Loop · Visite immobilière narrée par IA",
+    tagline: "Visite premium d'un penthouse avec narration IA",
+    category: SERVICE_CATEGORIES[2],
+    year: 2025,
+    duration: "01:05",
+    description:
+      "Visite immersive en drone FPV avec overlays data générés par Kling 2.5 et voix off Suno IA. Chaque pièce est présentée comme un chapitre et l'appel à l'action est piloté via QR code interactif.",
+    thumbnail: "https://images.unsplash.com/photo-1487956382158-bb926046304a?q=80&w=1200",
+    videoUrl: "https://www.youtube.com/watch?v=0pdqf4P9MB8",
+    gradient: gradientPool[2],
+    aiTools: ["Midjourney V7", "Kling 2.5", "Suno AI"],
+    deliverables: ["Film 16:9", "Version VR", "Carousel LinkedIn"],
+    socialStack: ["YouTube", "Website", "Meta Ads"],
+  },
+  {
+    id: uuid(),
+    title: "Snackverse · Série sociale pour WaveBite",
+    tagline: "Série verticale de 12 épisodes conçue pour la conversion",
+    category: SERVICE_CATEGORIES[3],
+    year: 2025,
+    duration: "00:45",
+    description:
+      "Production sociale verticale pilotée par IA : scripts testés via GPT CopyLab, tournage en LED volume, montage automatisé Veo 3 et templates livrés aux équipes internes.",
+    thumbnail: "https://images.unsplash.com/photo-1521737604893-d14cc237f11d?q=80&w=1200",
+    videoUrl: "https://www.youtube.com/watch?v=jNQXAC9IVRw",
+    gradient: gradientPool[3],
+    aiTools: ["Veo 3", "Midjourney V7", "Adobe Premiere Pro"],
+    deliverables: ["Série 12x45s", "Capsules additionnelles", "Scripts automatisés"],
+    socialStack: ["TikTok", "Snap", "YouTube Shorts"],
+  },
+  {
+    id: uuid(),
+    title: "Orbit Lovers · Mariage futuriste en live",
+    tagline: "Cérémonie captée en direct avec diffusion privée",
+    category: SERVICE_CATEGORIES[4],
+    year: 2024,
+    duration: "03:20",
+    description:
+      "Captation mariage premium : drones, steadycam, robot caméra et IA pour générer les vœux animés. Diffusion live privée et montage highlight livré avant la fin de la réception.",
+    thumbnail: "https://images.unsplash.com/photo-1520854221050-0f4caff449fb?q=80&w=1200",
+    videoUrl: "https://www.youtube.com/watch?v=oUFJJNQGwhk",
+    gradient: gradientPool[4],
+    aiTools: ["Seedance Pro", "DaVinci Resolve", "Suno AI"],
+    deliverables: ["Live multi-cam", "Highlight 3min", "Stories pour les invités"],
+    socialStack: ["YouTube privé", "Instagram", "Galerie partagée"],
+  },
+  {
+    id: uuid(),
+    title: "LogoVerse · Identité motion générée",
+    tagline: "Création d'identité motion design propulsée par l'IA",
+    category: SERVICE_CATEGORIES[5],
+    year: 2025,
+    duration: "00:36",
+    description:
+      "Création de logo animé via Midjourney V7 puis animatic Kling 2.5. Sound design Suno AI et packaging template pour diffusion OTT et dispositifs immersifs.",
+    thumbnail: "https://images.unsplash.com/photo-1545239351-1141bd82e8a6?q=80&w=1200",
+    videoUrl: "https://www.youtube.com/watch?v=ysz5S6PUM-U",
+    gradient: gradientPool[0],
+    aiTools: ["Midjourney V7", "Kling 2.5", "After Effects"],
+    deliverables: ["Logo animé 4 formats", "Banque transitions", "Kit son identité"],
+    socialStack: ["Behance", "Vimeo", "TikTok"],
+  },
+];
+
+const initialPricing: PricingTier[] = [
+  {
+    id: uuid(),
+    name: "Impulse",
+    price: 4200,
+    description: "Idéal pour un lancement ou un événement clé avec délais courts",
+    deliverables: ["Sprint créatif IA", "Tournage studio 4h", "Kit social 6 formats"],
+    sla: "Livraison 4K sous 72 heures",
+  },
+  {
+    id: uuid(),
+    name: "Hyperdrive",
+    price: 9700,
+    description: "Campagne multi-canal pilotée par notre pipeline intelligent",
+    deliverables: ["Storyboard Midjourney V7", "Tournage bi-cam", "Montage Davinci + VFX Veo 3"],
+    sla: "Pilotage complet sur 21 jours",
+  },
+  {
+    id: uuid(),
+    name: "Continuum",
+    price: 18200,
+    description: "Programme annuel incluant production continue, live et data storytelling",
+    deliverables: ["Retainer production mensuelle", "Lives trimestriels Seedance", "Veille tendances et optimisation"],
+    sla: "Équipe dédiée et dashboard 24/7",
+  },
+];
+
+const initialClients: ClientAccount[] = [
+  {
+    id: uuid(),
+    name: "Thomas Volberg",
+    email: "volberg.thomas@gmail.com",
+    password: "studioAdmin!42",
+    company: "Studio VBG",
+    industry: "Production vidéo",
+    membership: "Continuum",
+    avatarHue: 24,
+    lastProject: "Pulse HoloBoard",
+  },
+  {
+    id: uuid(),
+    name: "Lena Photon",
+    email: "lena@quantumwear.ai",
+    password: "studioVBG!",
+    company: "QuantumWear",
+    industry: "Tech santé",
+    membership: "Hyperdrive",
+    avatarHue: 182,
+    lastProject: "Sillage Quantique",
+  },
+];
+
+const initialQuotes: QuoteRequest[] = [
+  {
+    id: uuid(),
+    clientId: initialClients[1].id,
+    clientName: initialClients[1].name,
+    projectName: "Activation wearable SXSW",
+    budgetRange: "12k€ - 18k€",
+    deadline: "2025-03-11",
+    services: ["Captation multicam", "Scénarisation assistée par IA", "Pack réseaux sociaux"],
+    status: "en revue",
+    moodboardPrompt:
+      "Imagine a slow-motion capture of biometric data turning into aurora borealis patterns inside a dome stage.",
+    createdAt: new Date().toISOString(),
+  },
+];
+
+const initialChats: ChatThread[] = [
+  {
+    quoteId: initialQuotes[0].id,
+    clientName: initialClients[1].name,
+    projectName: initialQuotes[0].projectName,
+    messages: [
+      {
+        id: uuid(),
+        from: "client",
+        content: "On peut ajouter une version 9:16 verticale ?",
+        timestamp: new Date().toISOString(),
+      },
+      {
+        id: uuid(),
+        from: "studio",
+        content: "Bien sûr, on la génère via Veo 3 + montage Davinci. Je t'envoie le chiffrage dans 5 minutes.",
+        timestamp: new Date().toISOString(),
+      },
+    ],
+  },
+];
+
+const StudioProvider = ({ children }: { children: ReactNode }) => {
+  const [user, setUser] = useState<ClientAccount | null>(null);
+  const [clients, setClients] = useState<ClientAccount[]>(initialClients);
+  const [portfolioItems, setPortfolioItems] = useState<PortfolioItem[]>(initialPortfolio);
+  const [pricingTiers, setPricingTiers] = useState<PricingTier[]>(initialPricing);
+  const [quoteRequests, setQuoteRequests] = useState<QuoteRequest[]>(initialQuotes);
+  const [contactRequests, setContactRequests] = useState<ContactRequest[]>([]);
+  const [chats, setChats] = useState<ChatThread[]>(initialChats);
+  const [visualMode, setVisualMode] = useState<VisualMode>("nebula");
+
+  useEffect(() => {
+    const body = document.body;
+    body.classList.remove("visual-nebula", "visual-solstice");
+    body.classList.add(`visual-${visualMode}`);
+
+    const palette = visualPalettes[visualMode];
+    const root = document.documentElement;
+    root.style.setProperty("--visual-accent", palette.accent);
+    root.style.setProperty("--visual-accent-soft", palette.accentSoft);
+    root.style.setProperty("--visual-secondary", palette.secondary);
+    root.style.setProperty("--visual-tertiary", palette.tertiary);
+    root.style.setProperty("--visual-accent-foreground", palette.accentForeground);
+    root.style.setProperty("--visual-border", palette.border);
+  }, [visualMode]);
+
+  const cycleVisualMode = () => {
+    setVisualMode((current) => (current === "nebula" ? "solstice" : "nebula"));
+  };
+
+  const register: StudioContextValue["register"] = (payload) => {
+    const { email } = payload;
+    const exists = clients.some((client) => client.email === email);
+    if (exists) {
+      return { success: false, message: "Un compte utilise déjà cet email." };
+    }
+
+    const newClient: ClientAccount = {
+      ...payload,
+      id: uuid(),
+      avatarHue: Math.floor(Math.random() * 360),
+    };
+
+    setClients((prev) => [...prev, newClient]);
+    setUser(newClient);
+
+    return { success: true };
+  };
+
+  const login: StudioContextValue["login"] = (email, password) => {
+    const found = clients.find((client) => client.email === email && client.password === password);
+    if (!found) {
+      return { success: false, message: "Identifiants invalides ou compte inexistant." };
+    }
+
+    setUser(found);
+    return { success: true };
+  };
+
+  const logout = () => setUser(null);
+
+  const addPortfolioItem: StudioContextValue["addPortfolioItem"] = ({ gradient, ...payload }) => {
+    const newItem: PortfolioItem = {
+      ...payload,
+      id: uuid(),
+      gradient: gradient ?? gradientPool[Math.floor(Math.random() * gradientPool.length)],
+    };
+
+    setPortfolioItems((prev) => [newItem, ...prev]);
+  };
+
+  const updatePortfolioItem: StudioContextValue["updatePortfolioItem"] = (id, updates) => {
+    setPortfolioItems((prev) => prev.map((item) => (item.id === id ? { ...item, ...updates } : item)));
+  };
+
+  const removePortfolioItem: StudioContextValue["removePortfolioItem"] = (id) => {
+    setPortfolioItems((prev) => prev.filter((item) => item.id !== id));
+  };
+
+  const updatePricingTier: StudioContextValue["updatePricingTier"] = (id, updates) => {
+    setPricingTiers((prev) => prev.map((tier) => (tier.id === id ? { ...tier, ...updates } : tier)));
+  };
+
+  const createQuoteRequest: StudioContextValue["createQuoteRequest"] = (payload) => {
+    if (!user) return null;
+
+    const newQuote: QuoteRequest = {
+      ...payload,
+      id: uuid(),
+      clientId: user.id,
+      clientName: user.name,
+      status: "nouveau",
+      createdAt: new Date().toISOString(),
+    };
+
+    setQuoteRequests((prev) => [newQuote, ...prev]);
+    return newQuote;
+  };
+
+  const ensureChatThread = (quoteId: string, clientName: string, projectName: string) => {
+    setChats((prev) => {
+      const exists = prev.some((thread) => thread.quoteId === quoteId);
+      if (exists) return prev;
+      return [
+        ...prev,
+        {
+          quoteId,
+          clientName,
+          projectName,
+          messages: [
+            {
+              id: uuid(),
+              from: "studio",
+              content: "Bonjour, nous ouvrons ce canal pour préciser votre projet.",
+              timestamp: new Date().toISOString(),
+            },
+          ],
+        },
+      ];
+    });
+  };
+
+  const advanceQuoteStatus: StudioContextValue["advanceQuoteStatus"] = (id, status) => {
+    setQuoteRequests((prev) =>
+      prev.map((quote) => {
+        if (quote.id === id) {
+          if (status === "validé") {
+            ensureChatThread(quote.id, quote.clientName, quote.projectName);
+          }
+          return { ...quote, status };
+        }
+        return quote;
+      }),
+    );
+  };
+
+  const appendChatMessage: StudioContextValue["appendChatMessage"] = (quoteId, message) => {
+    setChats((prev) =>
+      prev.map((thread) =>
+        thread.quoteId === quoteId
+          ? {
+              ...thread,
+              messages: [
+                ...thread.messages,
+                {
+                  ...message,
+                  id: uuid(),
+                  timestamp: new Date().toISOString(),
+                },
+              ],
+            }
+          : thread,
+      ),
+    );
+  };
+
+  const recordContactRequest: StudioContextValue["recordContactRequest"] = (payload) => {
+    const newRequest: ContactRequest = {
+      ...payload,
+      id: uuid(),
+      createdAt: new Date().toISOString(),
+    };
+
+    setContactRequests((prev) => [newRequest, ...prev]);
+  };
+
+  const value: StudioContextValue = {
+    user,
+    clients,
+    portfolioItems,
+    pricingTiers,
+    quoteRequests,
+    contactRequests,
+    chats,
+    serviceCategories: SERVICE_CATEGORIES,
+    visualMode,
+    palette: visualPalettes[visualMode],
+    cycleVisualMode,
+    register,
+    login,
+    logout,
+    addPortfolioItem,
+    updatePortfolioItem,
+    removePortfolioItem,
+    updatePricingTier,
+    createQuoteRequest,
+    advanceQuoteStatus,
+    appendChatMessage,
+    recordContactRequest,
+  };
+
+  return <StudioContext.Provider value={value}>{children}</StudioContext.Provider>;
+};
+
+const useStudio = () => {
+  const context = useContext(StudioContext);
+  if (!context) {
+    throw new Error("useStudio doit être utilisé dans un StudioProvider");
+  }
+  return context;
+};
+
+export { StudioProvider, useStudio, SERVICE_CATEGORIES };

--- a/src/index.css
+++ b/src/index.css
@@ -53,6 +53,13 @@ All colors MUST be HSL.
     --sidebar-border: 220 13% 91%;
 
     --sidebar-ring: 217.2 91.2% 59.8%;
+
+    --visual-accent: 188 86% 64%;
+    --visual-accent-soft: 196 90% 78%;
+    --visual-secondary: 315 86% 66%;
+    --visual-tertiary: 251 96% 72%;
+    --visual-accent-foreground: 190 100% 92%;
+    --visual-border: 188 86% 64%;
   }
 
   .dark {
@@ -102,4 +109,89 @@ All colors MUST be HSL.
   body {
     @apply bg-background text-foreground;
   }
+
+  body.visual-nebula {
+    --visual-accent: 188 86% 64%;
+    --visual-accent-soft: 196 90% 78%;
+    --visual-secondary: 315 86% 66%;
+    --visual-tertiary: 251 96% 72%;
+    --visual-accent-foreground: 190 100% 92%;
+    --visual-border: 188 86% 64%;
+  }
+
+  body.visual-solstice {
+    --visual-accent: 34 97% 62%;
+    --visual-accent-soft: 17 94% 64%;
+    --visual-secondary: 296 76% 72%;
+    --visual-tertiary: 208 88% 70%;
+    --visual-accent-foreground: 35 100% 92%;
+    --visual-border: 34 97% 62%;
+  }
+}
+
+.visual-accent-text {
+  color: hsl(var(--visual-accent-foreground) / 0.8) !important;
+}
+
+.visual-accent-text-strong {
+  color: hsl(var(--visual-accent-foreground) / 0.95) !important;
+}
+
+.visual-accent-border {
+  border-color: hsla(var(--visual-border) / 0.45) !important;
+}
+
+.visual-accent-bg {
+  background-color: hsla(var(--visual-accent) / 0.18) !important;
+}
+
+.visual-accent-chip {
+  background-color: hsla(var(--visual-accent) / 0.12) !important;
+  color: hsl(var(--visual-accent-foreground) / 0.85) !important;
+}
+
+.visual-accent-dot {
+  background-color: hsl(var(--visual-accent) / 0.9) !important;
+  box-shadow: 0 0 12px hsla(var(--visual-accent) / 0.75) !important;
+}
+
+.visual-accent-gradient {
+  background-image: linear-gradient(
+      120deg,
+      hsla(var(--visual-accent) / 0.85),
+      hsla(var(--visual-secondary) / 0.75),
+      hsla(var(--visual-tertiary) / 0.8)
+    ) !important;
+}
+
+.visual-accent-underline {
+  text-decoration-color: hsla(var(--visual-accent) / 0.7) !important;
+}
+
+.visual-accent-shadow {
+  box-shadow: 0 10px 40px hsla(var(--visual-accent) / 0.32) !important;
+}
+
+.visual-accent-halo {
+  box-shadow: 0 25px 120px hsla(var(--visual-accent) / 0.2) !important;
+}
+
+.visual-accent-veil {
+  box-shadow: 0 20px 120px hsla(var(--visual-accent) / 0.18) !important;
+}
+
+.visual-accent-glow {
+  box-shadow: 0 15px 80px hsla(var(--visual-accent) / 0.22) !important;
+}
+
+.visual-accent-hover-shadow {
+  box-shadow: 0 35px 120px hsla(var(--visual-accent) / 0.24) !important;
+}
+
+.visual-secondary-veil {
+  box-shadow: 0 20px 100px hsla(var(--visual-secondary) / 0.18) !important;
+}
+
+.visual-secondary-glow {
+  box-shadow: 0 15px 50px hsla(var(--visual-secondary) / 0.28) !important;
 }

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -1,0 +1,38 @@
+export const navigationItems = [
+  {
+    label: "Accueil",
+    to: "/",
+    emoji: "🚀",
+    tooltip: "Page d'accueil",
+  },
+  {
+    label: "Services",
+    to: "/services",
+    emoji: "🎬",
+    tooltip: "Offres et méthodologie",
+  },
+  {
+    label: "Playground IA",
+    to: "/playground",
+    emoji: "🤖",
+    tooltip: "Laboratoires IA",
+  },
+  {
+    label: "Portfolio",
+    to: "/portfolio",
+    emoji: "📼",
+    tooltip: "Cas pratiques",
+  },
+  {
+    label: "Process",
+    to: "/process",
+    emoji: "🛰️",
+    tooltip: "Processus de production",
+  },
+  {
+    label: "Dashboard",
+    to: "/dashboard",
+    emoji: "🛠️",
+    tooltip: "Back-office",
+  },
+];

--- a/src/lib/services.ts
+++ b/src/lib/services.ts
@@ -1,0 +1,130 @@
+export type ServiceDetail = {
+  slug: string;
+  title: string;
+  subtitle: string;
+  problem: string;
+  promise: string;
+  stack: string[];
+  deliverables: string[];
+  phases: {
+    title: string;
+    description: string;
+    aiUpgrade: string;
+  }[];
+  signatureMove: string;
+  metrics: { label: string; value: string; note: string }[];
+};
+
+export const servicesData: ServiceDetail[] = [
+  {
+    slug: "captation-spectrale",
+    title: "Captation Spectrale",
+    subtitle: "Multi-cam, drone et plateau XR entièrement synchronisés",
+    problem: "Vous préparez un lancement stratégique ou un événement majeur qui exige une captation irréprochable sur chaque angle.",
+    promise:
+      "Nous orchestrons une réalisation premium avec régie automatisée, robotique Seedance Pro et compositing temps réel pour délivrer un rendu broadcast immédiatement exploitable.",
+    stack: ["Seedance Pro", "DaVinci Resolve", "Blackmagic Atem Scripting", "Audio Suno AI"],
+    deliverables: [
+      "Réalisations live multi-cam 12K",
+      "Mixage audio spatial et stems Suno",
+      "Capsules sociales instantanées",
+    ],
+    phases: [
+      {
+        title: "Pré-production",
+        description: "Repérages LiDAR, plan lumière anticipé par IA et trame éditoriale validée avec votre équipe.",
+        aiUpgrade: "Modélisation 3D Midjourney V7 et prévisualisation Kling 2.5 pour sécuriser les angles.",
+      },
+      {
+        title: "Captation",
+        description: "Pilotage robotisé, switcher automatisé et overlay data en direct pour garantir la continuité de service.",
+        aiUpgrade: "Seedance Pro anticipe les mouvements clés et optimise les transitions caméra.",
+      },
+      {
+        title: "Post-événement",
+        description: "Montage express, corrections colorimétriques et exports multi-formats prêts à diffuser.",
+        aiUpgrade: "Scripts IA pour générer les accroches et CTA adaptés à chaque réseau.",
+      },
+    ],
+    signatureMove: "Livraison d'une déclinaison 9:16 optimisée dans les 47 minutes suivant la fin de l'événement.",
+    metrics: [
+      { label: "Transitions caméra", value: "480", note: "pilotées par anticipation Seedance" },
+      { label: "Équipe plateau", value: "6", note: "réalisateurs, cadreurs et spécialistes IA" },
+      { label: "Taux de rétention", value: "+63%", note: "comparé à un livestream standard" },
+    ],
+  },
+  {
+    slug: "campagne-holo-sociale",
+    title: "Campagne Holo-Sociale",
+    subtitle: "Brand content orchestré pour chaque réseau et chaque format",
+    problem: "Vos audiences sont dispersées sur plusieurs plateformes et attendent des contenus différenciés mais cohérents.",
+    promise:
+      "Nous combinons narration, motion design et IA générative pour produire des campagnes multi-format parfaitement alignées avec votre image de marque.",
+    stack: ["Midjourney V7", "Veo 3", "Adobe After Effects", "Premiere Pro Sensei"],
+      deliverables: [
+        "Film héro + 12 contenus snack",
+        "Visuels corporate prêts à publier",
+        "Banque de visuels IA brandés",
+      ],
+    phases: [
+      {
+        title: "Atelier stratégique",
+        description: "Analyse des personas, cadrage des messages clés et définition de la grille éditoriale.",
+        aiUpgrade: "Prompt engineering Midjourney V7 et génération de scripts multi-tonalité par GPT-Voix.",
+      },
+      {
+        title: "Production",
+        description: "Tournages live, captations drone, motion design et avatars lip-sync selon les besoins.",
+        aiUpgrade: "LypSync V2 synchronise dialogues et voix générées en temps réel.",
+      },
+      {
+        title: "Déclinaisons",
+        description: "Montage modulaire, VFX data-driven et automatisation des exports selon les plateformes.",
+        aiUpgrade: "Veille tendance en temps réel pour ajuster les variations et recommandations de diffusion.",
+      },
+    ],
+    signatureMove: "Chaque déclinaison 9:16 intègre les optimisations IA nécessaires pour maximiser la rétention.",
+    metrics: [
+      { label: "Temps de production", value: "12 jours", note: "du brief à la mise en ligne" },
+      { label: "Variations IA", value: "128", note: "prompts ajustés en continu" },
+      { label: "UGC généré", value: "x4", note: "par rapport à une campagne standard" },
+    ],
+  },
+  {
+    slug: "programme-continuum",
+    title: "Programme Continuum",
+    subtitle: "Studio vidéo externalisé pour votre marque sur 12 mois",
+    problem: "Vous recherchez une production récurrente sans internaliser l'ensemble des compétences vidéo.",
+    promise:
+      "Studio VBG agit comme votre cellule vidéo intégrée : plan éditorial, tournages mensuels, lives trimestriels et analyses de performance.",
+    stack: ["DaVinci Resolve", "Notion Automations", "Adobe Premiere Pro", "Veo 3", "Kling 2.5"],
+    deliverables: [
+      "Roadmap éditoriale évolutive",
+      "Plateau captation récurrent",
+      "Dashboard ROI et insights",
+    ],
+    phases: [
+      {
+        title: "Onboarding",
+        description: "Audit des contenus existants, modélisation des audiences et définition des KPIs cibles.",
+        aiUpgrade: "Analyse sémantique GPT+ pour identifier les angles différenciants et opportunités éditoriales.",
+      },
+      {
+        title: "Production continue",
+        description: "Captations mensuelles, micro-formats récurrents et événements live trimestriels.",
+        aiUpgrade: "Planification automatisée et scripts IA personnalisés selon les actualités de votre marque.",
+      },
+      {
+        title: "Optimisation",
+        description: "Analyse de performance, recommandations éditoriales et ajustements créatifs en continu.",
+        aiUpgrade: "Dashboard IA pour générer des recommandations exploitables en un clic.",
+      },
+    ],
+    signatureMove: "Revue mensuelle structurée avec partage des indicateurs clés et arbitrages éditoriaux.",
+    metrics: [
+      { label: "Période", value: "12 mois", note: "offre renouvelable" },
+      { label: "ROI moyen", value: "x5.6", note: "sur les leads entrants" },
+      { label: "Charge opérationnelle", value: "-73%", note: "mesurée auprès de vos équipes marketing" },
+    ],
+  },
+];

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -1,0 +1,196 @@
+import { FormEvent, useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useStudio } from "@/context/StudioContext";
+
+const Auth = () => {
+  const [mode, setMode] = useState<"login" | "register">("register");
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const { register: registerUser, login, user } = useStudio();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const redirectPath = (location.state as { from?: string })?.from ?? "/dashboard";
+
+  const [form, setForm] = useState({
+    name: "",
+    email: "",
+    password: "",
+    company: "",
+    industry: "",
+    membership: "Hyperdrive" as const,
+  });
+
+  useEffect(() => {
+    if (user) {
+      navigate(redirectPath, { replace: true });
+    }
+  }, [user, navigate, redirectPath]);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setSuccess(null);
+
+    if (mode === "register") {
+      if (!form.name || !form.email || !form.password) {
+        setError("Merci de remplir tous les champs indispensables.");
+        return;
+      }
+      const response = registerUser(form);
+      if (response.success) {
+        setSuccess("Compte créé avec succès. Vous êtes désormais connecté·e.");
+      } else {
+        setError(response.message ?? "Impossible de créer le compte.");
+      }
+    } else {
+      const response = login(form.email, form.password);
+      if (!response.success) {
+        setError(response.message ?? "Impossible de se connecter.");
+      } else {
+        setSuccess("Connexion réussie. Vous pouvez préparer votre brief.");
+      }
+    }
+  };
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-white">
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{ background: "radial-gradient(circle at 10% 10%, hsla(var(--visual-accent)/0.22), transparent 60%)" }}
+      />
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{ background: "radial-gradient(circle at 90% 90%, hsla(var(--visual-secondary)/0.22), transparent 60%)" }}
+      />
+      <div className="relative mx-auto grid max-w-6xl grid-cols-1 gap-10 px-6 pb-24 pt-28 lg:grid-cols-[1.2fr_1fr]">
+        <div className="rounded-[3rem] border border-white/10 bg-white/5 p-12 shadow-[0_25px_120px_rgba(14,165,233,0.2)] visual-accent-halo">
+          <div className="space-y-6">
+            <span className="inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.35em] text-cyan-100/80 visual-accent-text-strong">
+              Studio VBG · Espace client
+            </span>
+            <h1 className="text-5xl font-black leading-tight">Accédez à l'espace client</h1>
+            <p className="text-lg text-slate-200/80">
+              Créez votre compte ou connectez-vous pour consulter le tableau de bord, déposer un brief, suivre vos devis et échanger avec nos équipes.
+            </p>
+            <div className="grid gap-4 text-sm text-slate-200/70 sm:grid-cols-2">
+              <div className="rounded-3xl border border-white/10 bg-white/10 p-5">
+                <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Onboarding structuré</p>
+                <p className="mt-2">Un formulaire clair pour rassembler les informations essentielles à votre projet.</p>
+              </div>
+              <div className="rounded-3xl border border-white/10 bg-white/10 p-5">
+                <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Sécurité maîtrisée</p>
+                <p className="mt-2">Vos données sont hébergées en interne et utilisées exclusivement pour vos projets.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <form
+          className="space-y-6 rounded-[3rem] border border-white/10 bg-white/10 p-10 shadow-[0_20px_100px_rgba(236,72,153,0.2)] visual-secondary-veil"
+          onSubmit={handleSubmit}
+        >
+          <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-slate-200/70">
+            <span>{mode === "register" ? "Créer un compte" : "Connexion"}</span>
+            <button
+              type="button"
+              onClick={() => {
+                setMode((prev) => (prev === "register" ? "login" : "register"));
+                setError(null);
+                setSuccess(null);
+              }}
+              className="rounded-full border border-white/20 px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-white"
+            >
+              {mode === "register" ? "J'ai déjà un compte" : "Créer un compte"}
+            </button>
+          </div>
+
+          {mode === "register" && (
+            <div className="space-y-4">
+              <div>
+                <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Nom complet</label>
+                <input
+                  className="mt-2 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                  value={form.name}
+                  onChange={(event) => setForm((prev) => ({ ...prev, name: event.target.value }))}
+                  placeholder="Nom et prénom"
+                  required
+                />
+              </div>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div>
+                  <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Entreprise</label>
+                  <input
+                    className="mt-2 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                    value={form.company}
+                    onChange={(event) => setForm((prev) => ({ ...prev, company: event.target.value }))}
+                    placeholder="Nom de l'entreprise"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Secteur</label>
+                  <input
+                    className="mt-2 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                    value={form.industry}
+                    onChange={(event) => setForm((prev) => ({ ...prev, industry: event.target.value }))}
+                    placeholder="Secteur d'activité"
+                    required
+                  />
+                </div>
+              </div>
+              <div>
+                <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Programme</label>
+                <select
+                  className="mt-2 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                  value={form.membership}
+                  onChange={(event) => setForm((prev) => ({ ...prev, membership: event.target.value as typeof prev.membership }))}
+                >
+                  <option value="Impulse">Impulse (starter)</option>
+                  <option value="Hyperdrive">Hyperdrive (campagne multi-format)</option>
+                  <option value="Continuum">Continuum (retainer annuel)</option>
+                </select>
+              </div>
+            </div>
+          )}
+
+          <div className="space-y-4">
+            <div>
+              <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Email</label>
+              <input
+                type="email"
+                className="mt-2 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                value={form.email}
+                onChange={(event) => setForm((prev) => ({ ...prev, email: event.target.value }))}
+                placeholder="vous@studio2025.com"
+                required
+              />
+            </div>
+            <div>
+              <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Mot de passe</label>
+              <input
+                type="password"
+                className="mt-2 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                value={form.password}
+                onChange={(event) => setForm((prev) => ({ ...prev, password: event.target.value }))}
+                placeholder="Au moins 8 caractères"
+                required
+              />
+            </div>
+          </div>
+
+          <button
+            type="submit"
+            className="group relative w-full overflow-hidden rounded-full border border-cyan-200/40 visual-accent-border bg-cyan-500/20 visual-accent-bg px-6 py-3 text-sm font-bold uppercase tracking-[0.3em] text-white"
+          >
+            <span className="relative z-10">{mode === "register" ? "Créer mon compte" : "Connexion"}</span>
+            <span className="absolute inset-0 translate-x-[-120%] bg-gradient-to-r from-cyan-400 via-sky-300 to-fuchsia-400 transition-transform duration-700 group-hover:translate-x-0 visual-accent-gradient" />
+          </button>
+
+          {error && <p className="rounded-2xl border border-rose-200/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-100">{error}</p>}
+          {success && <p className="rounded-2xl border border-emerald-200/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-100">{success}</p>}
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default Auth;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,0 +1,660 @@
+import { FormEvent, useMemo, useState, useCallback } from "react";
+import { useStudio } from "@/context/StudioContext";
+
+const ADMIN_EMAIL = "volberg.thomas@gmail.com";
+
+type PortfolioDraft = {
+  title: string;
+  tagline: string;
+  category: string;
+  year: number;
+  duration: string;
+  description: string;
+  thumbnail: string;
+  videoUrl: string;
+  aiTools: string;
+  deliverables: string;
+  socialStack: string;
+};
+
+const getDefaultProject = (categories: string[]): PortfolioDraft => ({
+  title: "",
+  tagline: "",
+  category: categories[0] ?? "Entreprise",
+  year: new Date().getFullYear(),
+  duration: "00:45",
+  description: "",
+  thumbnail: "",
+  videoUrl: "",
+  aiTools: "",
+  deliverables: "",
+  socialStack: "",
+});
+
+const Dashboard = () => {
+  const {
+    user,
+    clients,
+    portfolioItems,
+    pricingTiers,
+    quoteRequests,
+    contactRequests,
+    chats,
+    serviceCategories,
+    addPortfolioItem,
+    updatePortfolioItem,
+    removePortfolioItem,
+    updatePricingTier,
+    advanceQuoteStatus,
+    appendChatMessage,
+  } = useStudio();
+
+    const [newProject, setNewProject] = useState<PortfolioDraft>(() => getDefaultProject(serviceCategories));
+    const [chatInput, setChatInput] = useState("");
+    const [selectedChatId, setSelectedChatId] = useState(() => chats[0]?.quoteId ?? "");
+    const [youtubeUrl, setYoutubeUrl] = useState("");
+    const [isImportingMetadata, setIsImportingMetadata] = useState(false);
+    const [metadataError, setMetadataError] = useState<string | null>(null);
+    const [editDraft, setEditDraft] = useState<(PortfolioDraft & { id: string }) | null>(null);
+
+  const activeChat = useMemo(() => chats.find((chat) => chat.quoteId === selectedChatId), [chats, selectedChatId]);
+  const isAdmin = user?.email === ADMIN_EMAIL;
+
+  const resetNewProject = () => {
+    setNewProject(getDefaultProject(serviceCategories));
+    setYoutubeUrl("");
+    setMetadataError(null);
+  };
+
+  const extractYoutubeId = useCallback((url: string) => {
+    const match = url.match(/(?:v=|youtu\.be\/|embed\/)([A-Za-z0-9_-]{11})/);
+    return match?.[1] ?? null;
+  }, []);
+
+  const handleImportMetadata = useCallback(async () => {
+    if (!youtubeUrl.trim()) {
+      setMetadataError("Ajoutez un lien YouTube pour importer un projet.");
+      return;
+    }
+
+    const id = extractYoutubeId(youtubeUrl.trim());
+    if (!id) {
+      setMetadataError("Le lien YouTube n'est pas reconnu. Essayez avec l'URL complète.");
+      return;
+    }
+
+    setIsImportingMetadata(true);
+    setMetadataError(null);
+
+    const canonicalUrl = youtubeUrl.includes("http") ? youtubeUrl.trim() : `https://www.youtube.com/watch?v=${id}`;
+
+    try {
+      const oEmbedResponse = await fetch(`https://noembed.com/embed?url=${encodeURIComponent(canonicalUrl)}`);
+      if (!oEmbedResponse.ok) {
+        throw new Error("Impossible de récupérer les informations depuis YouTube.");
+      }
+      const oEmbedData = await oEmbedResponse.json();
+
+      let description = "";
+      try {
+        const pageResponse = await fetch(`https://r.jina.ai/https://www.youtube.com/watch?v=${id}`);
+        if (pageResponse.ok) {
+          const raw = await pageResponse.text();
+          const match = raw.match(/"shortDescription":"(.*?)"/);
+          if (match?.[1]) {
+            description = match[1]
+              .replace(/\\n/g, "\n")
+              .replace(/\\"/g, '"')
+              .replace(/\\'/g, "'");
+          }
+        }
+      } catch {
+        // Ignore description fallback when the YouTube page can't be fetched
+      }
+
+      const taglineCandidate = description
+        .split(/\n|\./)
+        .map((line) => line.trim())
+        .find((line) => line.length > 0);
+
+      setNewProject((prev) => ({
+        ...prev,
+        title: oEmbedData.title ?? prev.title,
+        tagline: taglineCandidate ?? prev.tagline,
+        description: description || prev.description,
+        thumbnail: oEmbedData.thumbnail_url ?? prev.thumbnail,
+        videoUrl: canonicalUrl,
+      }));
+    } catch (error) {
+      setMetadataError(error instanceof Error ? error.message : "Import impossible. Essayez manuellement.");
+    } finally {
+      setIsImportingMetadata(false);
+    }
+  }, [extractYoutubeId, youtubeUrl]);
+
+  if (!user) {
+    return null;
+  }
+
+  if (!isAdmin) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center bg-slate-950 px-6 text-center text-white">
+        <div className="max-w-lg space-y-6 rounded-[3rem] border border-white/10 bg-white/5 p-12">
+          <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Accès restreint</p>
+          <h1 className="text-4xl font-black leading-tight">Ce tableau de bord est réservé à l'équipe Studio VBG.</h1>
+          <p className="text-lg text-slate-200/80">
+            Connectez-vous avec le compte administrateur pour gérer le portfolio, les devis et les échanges clients.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const handleAddProject = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!newProject.videoUrl) {
+      setMetadataError("Ajoutez ou importez un lien YouTube pour ce projet.");
+      return;
+    }
+
+    addPortfolioItem({
+      title: newProject.title,
+      tagline: newProject.tagline,
+      category: newProject.category,
+      year: Number(newProject.year),
+      duration: newProject.duration,
+      description: newProject.description,
+      thumbnail:
+        newProject.thumbnail || "https://images.unsplash.com/photo-1504384308090-c894fdcc538d?q=80&w=1200",
+      videoUrl: newProject.videoUrl,
+      aiTools: newProject.aiTools.split(",").map((item) => item.trim()).filter(Boolean),
+      deliverables: newProject.deliverables.split(",").map((item) => item.trim()).filter(Boolean),
+      socialStack: newProject.socialStack.split(",").map((item) => item.trim()).filter(Boolean),
+    });
+
+    resetNewProject();
+  };
+
+  const startEditingProject = (projectId: string) => {
+    const project = portfolioItems.find((item) => item.id === projectId);
+    if (!project) return;
+
+    setEditDraft({
+      id: project.id,
+      title: project.title,
+      tagline: project.tagline,
+      category: project.category,
+      year: project.year,
+      duration: project.duration,
+      description: project.description,
+      thumbnail: project.thumbnail,
+      videoUrl: project.videoUrl,
+      aiTools: project.aiTools.join(", "),
+      deliverables: project.deliverables.join(", "),
+      socialStack: project.socialStack.join(", "),
+    });
+  };
+
+  const handleUpdateProject = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!editDraft) return;
+
+    updatePortfolioItem(editDraft.id, {
+      title: editDraft.title,
+      tagline: editDraft.tagline,
+      category: editDraft.category,
+      year: Number(editDraft.year),
+      duration: editDraft.duration,
+      description: editDraft.description,
+      thumbnail: editDraft.thumbnail,
+      videoUrl: editDraft.videoUrl,
+      aiTools: editDraft.aiTools.split(",").map((item) => item.trim()).filter(Boolean),
+      deliverables: editDraft.deliverables.split(",").map((item) => item.trim()).filter(Boolean),
+      socialStack: editDraft.socialStack.split(",").map((item) => item.trim()).filter(Boolean),
+    });
+
+    setEditDraft(null);
+  };
+
+  const cancelEdit = () => setEditDraft(null);
+
+  const handleSendMessage = () => {
+    if (!activeChat || !chatInput.trim()) return;
+    appendChatMessage(activeChat.quoteId, { from: "studio", content: chatInput.trim() });
+    setChatInput("");
+  };
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-white">
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{ background: "radial-gradient(circle at 15% 15%, hsla(var(--visual-accent)/0.25), transparent 60%)" }}
+      />
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{ background: "radial-gradient(circle at 85% 80%, hsla(var(--visual-secondary)/0.2), transparent 60%)" }}
+      />
+      <div className="relative mx-auto max-w-7xl px-6 pb-32 pt-24">
+        <header className="rounded-[3rem] border border-white/10 bg-white/5 p-12 shadow-[0_20px_120px_rgba(14,165,233,0.2)] visual-accent-veil">
+          <div className="flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
+            <div className="space-y-6">
+              <span className="inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.35em] text-cyan-100/80 visual-accent-text-strong">
+                Dashboard Studio VBG
+              </span>
+              <h1 className="text-5xl font-black leading-tight">Bienvenue {user.name.split(" ")[0]}</h1>
+              <p className="text-lg text-slate-200/80">
+                Gérez vos projets, suivez vos devis, ajustez vos tarifs et discutez avec nos équipes. Tout est synchronisé avec notre pipeline IA.
+              </p>
+            </div>
+            <div className="rounded-[2.5rem] border border-white/10 bg-white/10 p-8 text-sm text-slate-200/80">
+              <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Stat instantané</p>
+              <p className="mt-3 text-white">{portfolioItems.length} projets en cours · {quoteRequests.length} devis · {contactRequests.length} demandes rapides</p>
+            </div>
+          </div>
+        </header>
+
+        <section className="mt-16 grid gap-10 xl:grid-cols-[1.1fr_0.9fr]">
+          <div className="space-y-10">
+            <div className="rounded-[3rem] border border-white/10 bg-white/10 p-10 shadow-[0_20px_100px_rgba(56,189,248,0.18)] visual-accent-veil">
+              <h2 className="text-2xl font-bold">Ajouter un projet au portfolio</h2>
+              <p className="mt-2 text-sm text-slate-200/70">Ajoutez, modifiez, supprimez librement les projets visibles côté vitrine.</p>
+              <form className="mt-6 grid gap-4" onSubmit={handleAddProject}>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <input
+                    required
+                    value={newProject.title}
+                    onChange={(event) => setNewProject((prev) => ({ ...prev, title: event.target.value }))}
+                    placeholder="Titre"
+                    className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                  />
+                  <input
+                    required
+                    value={newProject.tagline}
+                    onChange={(event) => setNewProject((prev) => ({ ...prev, tagline: event.target.value }))}
+                    placeholder="Tagline"
+                    className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                  />
+                </div>
+                <div className="grid gap-4 sm:grid-cols-[1.5fr_auto]">
+                  <input
+                    value={youtubeUrl}
+                    onChange={(event) => setYoutubeUrl(event.target.value)}
+                    placeholder="Lien YouTube (youtu.be ou youtube.com)"
+                    className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                  />
+                  <button
+                    type="button"
+                    onClick={handleImportMetadata}
+                    disabled={isImportingMetadata}
+                    className="rounded-full border border-cyan-200/40 visual-accent-border bg-cyan-500/20 visual-accent-bg px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {isImportingMetadata ? "Import..." : "Importer"}
+                  </button>
+                </div>
+                {metadataError && <p className="text-xs text-rose-300">{metadataError}</p>}
+                <div className="grid gap-4 sm:grid-cols-4">
+                  <select
+                    value={newProject.category}
+                    onChange={(event) => setNewProject((prev) => ({ ...prev, category: event.target.value }))}
+                    className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                  >
+                    {serviceCategories.map((category) => (
+                      <option key={category} value={category} className="bg-slate-900 text-white">
+                        {category}
+                      </option>
+                    ))}
+                  </select>
+                  <input
+                    value={newProject.year}
+                    type="number"
+                    onChange={(event) => setNewProject((prev) => ({ ...prev, year: Number(event.target.value) }))}
+                    placeholder="Année"
+                    className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                  />
+                  <input
+                    value={newProject.duration}
+                    onChange={(event) => setNewProject((prev) => ({ ...prev, duration: event.target.value }))}
+                    placeholder="Durée"
+                    className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                  />
+                  <input
+                    value={newProject.videoUrl}
+                    onChange={(event) => setNewProject((prev) => ({ ...prev, videoUrl: event.target.value }))}
+                    placeholder="Lien vidéo final"
+                    className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                  />
+                </div>
+                <input
+                  value={newProject.thumbnail}
+                  onChange={(event) => setNewProject((prev) => ({ ...prev, thumbnail: event.target.value }))}
+                  placeholder="URL vignette (optionnel si import)"
+                  className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                />
+                <textarea
+                  value={newProject.description}
+                  onChange={(event) => setNewProject((prev) => ({ ...prev, description: event.target.value }))}
+                  rows={4}
+                  placeholder="Description punchy"
+                  className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                />
+                <div className="grid gap-4 sm:grid-cols-3">
+                  <input
+                    value={newProject.aiTools}
+                    onChange={(event) => setNewProject((prev) => ({ ...prev, aiTools: event.target.value }))}
+                    placeholder="IA tools (séparés par virgule)"
+                    className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                  />
+                  <input
+                    value={newProject.deliverables}
+                    onChange={(event) => setNewProject((prev) => ({ ...prev, deliverables: event.target.value }))}
+                    placeholder="Livrables"
+                    className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                  />
+                  <input
+                    value={newProject.socialStack}
+                    onChange={(event) => setNewProject((prev) => ({ ...prev, socialStack: event.target.value }))}
+                    placeholder="Stack social"
+                    className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                  />
+                </div>
+                <div className="flex flex-wrap gap-4">
+                  <button
+                    type="submit"
+                    className="rounded-full border border-cyan-200/40 visual-accent-border bg-cyan-500/20 visual-accent-bg px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white"
+                  >
+                    Ajouter au portfolio
+                  </button>
+                  <button
+                    type="button"
+                    onClick={resetNewProject}
+                    className="rounded-full border border-white/20 bg-white/10 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white"
+                  >
+                    Réinitialiser
+                  </button>
+                </div>
+              </form>
+              {editDraft && (
+                <form className="mt-10 grid gap-4 rounded-[2.5rem] border border-white/10 bg-white/5 p-6" onSubmit={handleUpdateProject}>
+                  <div className="flex items-center justify-between">
+                    <h3 className="text-lg font-semibold text-white">Modifier : {editDraft.title}</h3>
+                    <button type="button" onClick={cancelEdit} className="text-xs uppercase tracking-[0.3em] text-rose-300 hover:text-rose-200">
+                      Annuler
+                    </button>
+                  </div>
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <input
+                      required
+                      value={editDraft.title}
+                      onChange={(event) => setEditDraft((prev) => (prev ? { ...prev, title: event.target.value } : prev))}
+                      placeholder="Titre"
+                      className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                    />
+                    <input
+                      required
+                      value={editDraft.tagline}
+                      onChange={(event) => setEditDraft((prev) => (prev ? { ...prev, tagline: event.target.value } : prev))}
+                      placeholder="Tagline"
+                      className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                    />
+                  </div>
+                  <div className="grid gap-4 sm:grid-cols-4">
+                    <select
+                      value={editDraft.category}
+                      onChange={(event) => setEditDraft((prev) => (prev ? { ...prev, category: event.target.value } : prev))}
+                      className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                    >
+                      {serviceCategories.map((category) => (
+                        <option key={category} value={category} className="bg-slate-900 text-white">
+                          {category}
+                        </option>
+                      ))}
+                    </select>
+                    <input
+                      value={editDraft.year}
+                      type="number"
+                      onChange={(event) => setEditDraft((prev) => (prev ? { ...prev, year: Number(event.target.value) } : prev))}
+                      placeholder="Année"
+                      className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                    />
+                    <input
+                      value={editDraft.duration}
+                      onChange={(event) => setEditDraft((prev) => (prev ? { ...prev, duration: event.target.value } : prev))}
+                      placeholder="Durée"
+                      className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                    />
+                    <input
+                      value={editDraft.videoUrl}
+                      onChange={(event) => setEditDraft((prev) => (prev ? { ...prev, videoUrl: event.target.value } : prev))}
+                      placeholder="Lien vidéo"
+                      className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                    />
+                  </div>
+                  <textarea
+                    value={editDraft.description}
+                    onChange={(event) => setEditDraft((prev) => (prev ? { ...prev, description: event.target.value } : prev))}
+                    rows={4}
+                    placeholder="Description"
+                    className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                  />
+                  <div className="grid gap-4 sm:grid-cols-3">
+                    <input
+                      value={editDraft.thumbnail}
+                      onChange={(event) => setEditDraft((prev) => (prev ? { ...prev, thumbnail: event.target.value } : prev))}
+                      placeholder="Vignette"
+                      className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                    />
+                    <input
+                      value={editDraft.aiTools}
+                      onChange={(event) => setEditDraft((prev) => (prev ? { ...prev, aiTools: event.target.value } : prev))}
+                      placeholder="IA Tools"
+                      className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                    />
+                    <input
+                      value={editDraft.deliverables}
+                      onChange={(event) => setEditDraft((prev) => (prev ? { ...prev, deliverables: event.target.value } : prev))}
+                      placeholder="Livrables"
+                      className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                    />
+                  </div>
+                  <input
+                    value={editDraft.socialStack}
+                    onChange={(event) => setEditDraft((prev) => (prev ? { ...prev, socialStack: event.target.value } : prev))}
+                    placeholder="Stack social"
+                    className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                  />
+                  <div className="flex flex-wrap gap-4">
+                    <button
+                      type="submit"
+                      className="rounded-full border border-cyan-200/40 visual-accent-border bg-cyan-500/20 visual-accent-bg px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white"
+                    >
+                      Sauvegarder
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        if (editDraft) {
+                          removePortfolioItem(editDraft.id);
+                          setEditDraft(null);
+                        }
+                      }}
+                      className="rounded-full border border-rose-300/60 bg-rose-500/20 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-rose-100"
+                    >
+                      Supprimer
+                    </button>
+                  </div>
+                </form>
+              )}
+              <div className="mt-6 grid gap-4 text-sm text-slate-200/70 sm:grid-cols-2">
+                {portfolioItems.map((item) => (
+                  <div key={item.id} className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                    <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em]">
+                      <span>{item.category}</span>
+                      <div className="flex items-center gap-3">
+                        <button
+                          type="button"
+                          onClick={() => startEditingProject(item.id)}
+                          className="text-cyan-200 hover:text-cyan-100"
+                        >
+                          Modifier
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => removePortfolioItem(item.id)}
+                          className="text-rose-300 hover:text-rose-200"
+                        >
+                          Supprimer
+                        </button>
+                      </div>
+                    </div>
+                    <p className="mt-2 font-semibold text-white">{item.title}</p>
+                    <p className="text-xs text-slate-200/60">{item.tagline}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-[3rem] border border-white/10 bg-white/10 p-10 shadow-[0_20px_100px_rgba(236,72,153,0.18)] visual-secondary-veil">
+              <h2 className="text-2xl font-bold">Gestion des tarifs</h2>
+              <div className="mt-6 grid gap-4 sm:grid-cols-3">
+                {pricingTiers.map((tier) => (
+                  <div key={tier.id} className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                    <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">{tier.name}</p>
+                    <input
+                      type="number"
+                      className="mt-3 w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                      value={tier.price}
+                      onChange={(event) => updatePricingTier(tier.id, { price: Number(event.target.value) })}
+                    />
+                    <p className="mt-2 text-xs text-slate-200/60">{tier.description}</p>
+                    <p className="mt-2 text-xs text-slate-200/60">{tier.sla}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <aside className="space-y-10">
+            <div className="rounded-[3rem] border border-white/10 bg-white/10 p-8 shadow-[0_20px_80px_rgba(56,189,248,0.15)] visual-accent-veil">
+              <h2 className="text-2xl font-bold">Comptes clients</h2>
+              <div className="mt-4 space-y-4 text-sm text-slate-200/70">
+                {clients.map((client) => (
+                  <div key={client.id} className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="font-semibold text-white">{client.name}</p>
+                        <p className="text-xs text-slate-200/60">{client.email}</p>
+                      </div>
+                      <span className="rounded-full border border-white/20 px-3 py-1 text-xs uppercase tracking-[0.3em] text-cyan-200/80 visual-accent-text">
+                        {client.membership}
+                      </span>
+                    </div>
+                    <p className="mt-2 text-xs text-slate-200/60">{client.company} · {client.industry}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-[3rem] border border-white/10 bg-white/10 p-8 shadow-[0_20px_80px_rgba(236,72,153,0.15)] visual-secondary-veil">
+              <h2 className="text-2xl font-bold">Demandes de devis</h2>
+              <div className="mt-4 space-y-4 text-sm text-slate-200/70">
+                {quoteRequests.map((quote) => (
+                  <div key={quote.id} className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="font-semibold text-white">{quote.projectName}</p>
+                        <p className="text-xs text-slate-200/60">{quote.clientName} · {quote.budgetRange}</p>
+                      </div>
+                      <select
+                        value={quote.status}
+                        onChange={(event) => advanceQuoteStatus(quote.id, event.target.value as typeof quote.status)}
+                        className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs uppercase tracking-[0.3em] text-white"
+                      >
+                        <option value="nouveau">Nouveau</option>
+                        <option value="en revue">En revue</option>
+                        <option value="validé">Validé</option>
+                        <option value="refusé">Refusé</option>
+                      </select>
+                    </div>
+                    <p className="mt-2 text-xs text-slate-200/60">Deadline : {quote.deadline}</p>
+                    <p className="mt-2 text-xs text-slate-200/60">Services : {quote.services.join(", ")}</p>
+                    <button
+                      type="button"
+                      onClick={() => setSelectedChatId(quote.id)}
+                      className="mt-3 rounded-full border border-cyan-200/40 visual-accent-border bg-cyan-500/20 visual-accent-bg px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-white"
+                    >
+                      Ouvrir le chat
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-[3rem] border border-white/10 bg-white/10 p-8 shadow-[0_20px_80px_rgba(34,211,238,0.18)]">
+              <h2 className="text-2xl font-bold">Chat style SMS</h2>
+              <div className="mt-4 flex gap-4">
+                <div className="w-1/3 space-y-2 text-xs text-slate-200/70">
+                  {chats.map((thread) => (
+                    <button
+                      key={thread.quoteId}
+                      type="button"
+                      onClick={() => setSelectedChatId(thread.quoteId)}
+                      className={`w-full rounded-2xl border px-3 py-2 text-left ${
+                        thread.quoteId === selectedChatId ? "border-cyan-300 bg-white/20" : "border-white/10 bg-white/5"
+                      }`}
+                    >
+                      <p className="font-semibold text-white">{thread.clientName}</p>
+                      <p className="text-[0.65rem] text-slate-200/60">{thread.projectName}</p>
+                    </button>
+                  ))}
+                </div>
+                <div className="flex-1 rounded-2xl border border-white/10 bg-slate-950/60 p-4">
+                  {activeChat ? (
+                    <div className="flex h-full flex-col">
+                      <div className="flex-1 space-y-3 overflow-y-auto pr-2">
+                        {activeChat.messages.map((message) => (
+                          <div
+                            key={message.id}
+                            className={`max-w-[80%] rounded-2xl px-4 py-3 text-sm ${
+                              message.from === "studio"
+                                ? "ml-auto bg-cyan-500/20 visual-accent-bg text-cyan-100 visual-accent-text-strong"
+                                : "bg-white/10 text-slate-100"
+                            }`}
+                          >
+                            <p>{message.content}</p>
+                            <p className="mt-1 text-[0.6rem] uppercase tracking-[0.2em] text-slate-200/50">
+                              {new Date(message.timestamp).toLocaleString()}
+                            </p>
+                          </div>
+                        ))}
+                      </div>
+                      <div className="mt-4 flex items-center gap-2">
+                        <input
+                          value={chatInput}
+                          onChange={(event) => setChatInput(event.target.value)}
+                          placeholder="Répondre avec panache"
+                          className="flex-1 rounded-full border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                        />
+                        <button
+                          type="button"
+                          onClick={handleSendMessage}
+                          className="rounded-full border border-cyan-200/40 visual-accent-border bg-cyan-500/20 visual-accent-bg px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white"
+                        >
+                          Envoyer
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <p className="text-sm text-slate-200/70">Aucun chat sélectionné.</p>
+                  )}
+                </div>
+              </div>
+            </div>
+          </aside>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,11 +1,365 @@
-// Update this page (the content is just a fallback if you fail to update the page)
+import { Link } from "react-router-dom";
+import { useState } from "react";
+import { useStudio } from "@/context/StudioContext";
+import { servicesData } from "@/lib/services";
+
+const heroHooks = [
+  "Votre direction attend des résultats tangibles : nous concevons des productions qui les démontrent.",
+  "Les plateformes privilégient les contenus cohérents. Chaque format est calibré pour sa diffusion.",
+  "Les échéances serrées exigent une organisation impeccable. Notre équipe reste mobilisée du brief au delivery.",
+];
+
+const techStack = [
+  "Midjourney V7",
+  "Kling 2.5",
+  "Seedance Pro",
+  "Veo 3",
+  "Suno AI",
+  "LypSync V2",
+  "DaVinci Resolve",
+  "Adobe Video Sensei",
+];
 
 const Index = () => {
+  const { portfolioItems, recordContactRequest } = useStudio();
+  const [hookIndex, setHookIndex] = useState(0);
+  const [contactSent, setContactSent] = useState(false);
+  const [form, setForm] = useState({
+    name: "",
+    email: "",
+    projectSpark: "",
+    urgency: "hier" as const,
+  });
+
+  const heroProject = portfolioItems[0];
+
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background">
-      <div className="text-center">
-        <h1 className="mb-4 text-4xl font-bold">Welcome to Your Blank App</h1>
-        <p className="text-xl text-muted-foreground">Start building your amazing project here!</p>
+    <div className="relative min-h-screen overflow-x-hidden bg-slate-950 text-white">
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{ background: "radial-gradient(circle at top, hsla(var(--visual-accent)/0.35), transparent 55%)" }}
+      />
+      <div
+        className="pointer-events-none absolute inset-0 animate-[spin_20s_linear_infinite]"
+        style={{
+          background:
+            "conic-gradient(from 45deg at 30% 30%, hsla(var(--visual-accent-soft)/0.22), hsla(var(--visual-secondary)/0.2), transparent 70%)",
+        }}
+      />
+      <div className="relative">
+        <header className="mx-auto flex max-w-7xl flex-col gap-12 px-6 pt-20 pb-28 lg:flex-row lg:items-center">
+          <div className="flex-1 space-y-10">
+            <span className="inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.35em] text-slate-200 backdrop-blur">
+              Studio VBG · Agence vidéo 2025
+            </span>
+            <h1 className="text-4xl font-black leading-tight sm:text-6xl">
+              <span className="bg-gradient-to-r from-cyan-400 via-sky-200 to-fuchsia-400 bg-clip-text text-transparent visual-accent-gradient">
+                Studio VBG
+              </span>{" "}
+              orchestre vos contenus vidéo avec une précision cinématographique.
+            </h1>
+            <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-6 text-lg leading-relaxed shadow-[0_0_60px_rgba(56,189,248,0.25)] visual-accent-shadow">
+              <div className="absolute inset-y-0 right-0 w-px bg-gradient-to-b from-transparent via-white/30 to-transparent" />
+              <p className="font-semibold uppercase tracking-[0.2em] text-cyan-200/80 visual-accent-text">Message clé</p>
+              <p className="mt-4 text-2xl" onMouseEnter={() => setHookIndex((i) => (i + 1) % heroHooks.length)}>
+                {heroHooks[hookIndex]}
+              </p>
+              <p className="mt-6 text-sm text-slate-200/80">
+                Nous combinons conception éditoriale, pipeline IA et expertise plateau pour transformer chaque vidéo en actif durable.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-4">
+              <Link
+                to="/quote"
+                className="group relative overflow-hidden rounded-full border border-cyan-200/30 visual-accent-border bg-cyan-500/20 visual-accent-bg px-8 py-4 text-sm font-bold uppercase tracking-[0.3em] text-cyan-100 visual-accent-text-strong shadow-[0_10px_40px_rgba(8,145,178,0.35)] visual-accent-shadow transition hover:scale-105"
+              >
+                <span className="relative z-10 flex items-center gap-3">
+                  <span className="text-xl">⚡</span> Demande de devis
+                </span>
+                <span className="absolute inset-0 -z-0 translate-y-full bg-gradient-to-r from-cyan-400 via-sky-300 to-fuchsia-500 visual-accent-gradient transition-all duration-500 group-hover:translate-y-0 visual-accent-gradient" />
+              </Link>
+              <a
+                href="#contact"
+                className="group relative overflow-hidden rounded-full border border-white/20 px-8 py-4 text-sm font-bold uppercase tracking-[0.3em] text-white transition hover:scale-105"
+              >
+                <span className="relative z-10 flex items-center gap-3">
+                  <span className="text-xl">📞</span> Demande rapide
+                </span>
+                <span className="absolute inset-0 -z-0 translate-y-full bg-white/20 transition-all duration-500 group-hover:translate-y-0" />
+              </a>
+            </div>
+            <div className="grid gap-4 text-sm text-slate-300/80 sm:grid-cols-2">
+              <div className="rounded-3xl border border-white/10 bg-white/5 p-4 backdrop-blur">
+                <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Chaîne IA</p>
+                <p className="mt-2 font-semibold text-white">Midjourney V7 · Kling 2.5 · Seedance Pro · Veo 3 · Suno AI · LypSync V2</p>
+              </div>
+              <div className="rounded-3xl border border-white/10 bg-white/5 p-4 backdrop-blur">
+                <p className="text-xs uppercase tracking-[0.3em] text-fuchsia-200/70">Résultats 2024</p>
+                <p className="mt-2 font-semibold text-white">+320% d'engagement moyen · 48h pour produire un bundle complet</p>
+              </div>
+            </div>
+          </div>
+          <div className="flex flex-1 flex-col gap-6">
+            <div className="relative overflow-hidden rounded-[2.5rem] border border-white/10 bg-white/5 p-6 shadow-[0_30px_120px_rgba(236,72,153,0.2)] visual-accent-halo">
+              <div
+                className="absolute inset-0"
+                style={{ background: "radial-gradient(circle at 20% 20%, hsla(var(--visual-secondary)/0.3), transparent 65%)" }}
+              />
+              <div className="relative space-y-6">
+                <p className="text-xs uppercase tracking-[0.4em] text-fuchsia-200/70">Cas phare</p>
+                <h2 className="text-2xl font-bold leading-tight">{heroProject?.title}</h2>
+                <p className="text-slate-200/80">{heroProject?.tagline}</p>
+                <div className="grid gap-3 text-xs font-semibold uppercase tracking-[0.2em] text-slate-200/70 sm:grid-cols-3">
+                  <div className="rounded-2xl bg-white/5 p-3 text-center">{heroProject?.category}</div>
+                  <div className="rounded-2xl bg-white/5 p-3 text-center">{heroProject?.duration}</div>
+                  <div className="rounded-2xl bg-white/5 p-3 text-center">{heroProject?.year}</div>
+                </div>
+                <img
+                  src={heroProject?.thumbnail}
+                  alt={heroProject?.title}
+                  className="h-64 w-full rounded-[2rem] object-cover object-center"
+                />
+                <div className="flex flex-wrap gap-2 text-xs text-cyan-100/80 visual-accent-text-strong">
+                  {heroProject?.aiTools.map((tool) => (
+                    <span key={tool} className="rounded-full bg-cyan-500/20 visual-accent-bg px-3 py-1">{tool}</span>
+                  ))}
+                </div>
+              </div>
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2">
+              {techStack.slice(0, 4).map((tool) => (
+                <div key={tool} className="rounded-3xl border border-white/10 bg-gradient-to-br from-white/10 to-white/5 p-4">
+                  <p className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Stack</p>
+                  <p className="mt-2 text-lg font-bold text-white">{tool}</p>
+                  <p className="text-[0.75rem] text-slate-200/70">Automatisé, documenté, prêt pour vos contenus.</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </header>
+
+        <section className="relative mx-auto max-w-6xl px-6 pb-24">
+          <div
+            className="absolute inset-0 -z-10 blur-3xl"
+            style={{ background: "radial-gradient(circle at 20% 20%, hsla(var(--visual-accent)/0.18), transparent 60%)" }}
+          />
+          <div className="rounded-[3rem] border border-white/10 bg-white/5 p-10 shadow-[0_0_80px_rgba(59,130,246,0.15)] visual-accent-veil">
+            <div className="flex flex-col items-start gap-6 pb-10 lg:flex-row lg:items-center lg:justify-between">
+              <div>
+                <p className="text-sm uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Méthode intégrée</p>
+                <h2 className="mt-3 text-4xl font-extrabold">
+                  Une chaîne de production qui synchronise IA et équipes de plateau
+                </h2>
+              </div>
+              <div className="flex gap-3 text-sm text-slate-200/80">
+                {techStack.map((tool) => (
+                  <span
+                    key={tool}
+                    className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-3 py-1"
+                  >
+                    <span className="h-2 w-2 rounded-full bg-cyan-300 visual-accent-dot" /> {tool}
+                  </span>
+                ))}
+              </div>
+            </div>
+            <div className="grid gap-6 lg:grid-cols-3">
+              {servicesData.map((service, index) => (
+                <Link
+                  key={service.slug}
+                  to={`/services/${service.slug}`}
+                  className="group relative overflow-hidden rounded-[2rem] border border-white/10 bg-gradient-to-br from-white/10 to-white/5 p-8 shadow-[0_30px_100px_rgba(56,189,248,0.12)] visual-accent-hover-shadow transition-transform duration-500 hover:-translate-y-2"
+                >
+                  <span className="absolute inset-0 translate-y-full bg-gradient-to-t from-cyan-500/30 via-transparent to-transparent visual-accent-gradient transition-transform duration-700 group-hover:translate-y-0 visual-accent-gradient" />
+                  <div className="relative space-y-4">
+                    <span className="inline-flex items-center gap-3 text-sm font-semibold text-cyan-200/80 visual-accent-text">
+                      <span className="text-2xl">0{index + 1}</span> {service.title}
+                    </span>
+                    <p className="text-xl font-bold text-white">{service.subtitle}</p>
+                    <p className="text-sm text-slate-200/80">{service.promise}</p>
+                    <div className="flex flex-wrap gap-2 text-xs text-cyan-100/70 visual-accent-text-strong">
+                      {service.stack.map((tool) => (
+                        <span key={tool} className="rounded-full bg-cyan-500/10 visual-accent-chip px-3 py-1">
+                          {tool}
+                        </span>
+                      ))}
+                    </div>
+                    <p className="text-xs uppercase tracking-[0.3em] text-slate-300/70">
+                      Consulter la méthodologie →
+                    </p>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="relative mx-auto max-w-6xl px-6 pb-24">
+          <div className="flex flex-col gap-10 lg:flex-row">
+            <div className="flex-1 space-y-6">
+              <p className="text-sm uppercase tracking-[0.3em] text-fuchsia-200/70">Réalisations récentes</p>
+              <h2 className="text-4xl font-extrabold leading-tight">
+                Un portefeuille modulable piloté depuis votre tableau de bord
+              </h2>
+              <p className="text-lg text-slate-200/80">
+                Chaque projet est structuré pour évoluer. Ajoutez, mettez à jour ou archivez vos références depuis le tableau de bord administrateur.
+              </p>
+              <div className="grid gap-4 text-sm text-slate-200/80">
+                <div className="rounded-3xl border border-white/10 bg-white/5 p-5">
+                  <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/60 visual-accent-text">Processus éditorial</p>
+                  <p className="mt-2">Brief, scénario, droits et livrables sont documentés dès la préproduction pour sécuriser la validation interne.</p>
+                </div>
+                <div className="rounded-3xl border border-white/10 bg-white/5 p-5">
+                  <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/60 visual-accent-text">Pilotage data</p>
+                  <p className="mt-2">Classement par thématique, scoring IA des performances et bibliothèques audio certifiées pour accélérer la production.</p>
+                </div>
+              </div>
+              <Link
+                to="/portfolio"
+                className="inline-flex items-center gap-3 rounded-full border border-fuchsia-200/40 bg-fuchsia-500/20 px-6 py-3 text-sm font-semibold uppercase tracking-[0.25em] text-white shadow-[0_15px_50px_rgba(236,72,153,0.3)] visual-secondary-glow visual-accent-glow"
+              >
+                Explorer la galerie complète
+              </Link>
+            </div>
+            <div className="flex-1 space-y-6">
+              {portfolioItems.slice(0, 3).map((project, index) => (
+                <article
+                  key={project.id}
+                  className={`group relative overflow-hidden rounded-[2.5rem] border border-white/10 bg-gradient-to-br from-white/10 to-white/5 p-6 shadow-[0_25px_90px_rgba(244,114,182,0.12)] visual-accent-hover-shadow transition-all duration-500 hover:-translate-y-2 hover:shadow-[0_35px_120px_rgba(14,165,233,0.2)] visual-accent-hover-shadow`}
+                >
+                  <span
+                    className="absolute inset-0 -z-10 opacity-0 transition-opacity duration-700 group-hover:opacity-100"
+                    style={{
+                      background:
+                        "linear-gradient(120deg, hsla(var(--visual-accent)/0.25), hsla(var(--visual-secondary)/0.2))",
+                    }}
+                  />
+                  <div className="relative flex flex-col gap-4">
+                    <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-slate-200/70">
+                      <span>Projet 0{index + 1}</span>
+                      <span>{project.category}</span>
+                    </div>
+                    <h3 className="text-2xl font-bold text-white">{project.title}</h3>
+                    <p className="text-sm text-slate-200/80">{project.description}</p>
+                    <div className="grid gap-3 text-xs text-cyan-100/80 visual-accent-text-strong sm:grid-cols-3">
+                      <div className="rounded-2xl bg-white/5 p-3 text-center">{project.duration}</div>
+                      <div className="rounded-2xl bg-white/5 p-3 text-center">{project.year}</div>
+                      <div className="rounded-2xl bg-white/5 p-3 text-center">{project.socialStack[0]}</div>
+                    </div>
+                    <img src={project.thumbnail} alt={project.title} className="h-56 w-full rounded-[2rem] object-cover" />
+                  </div>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="relative mx-auto max-w-6xl px-6 pb-24" id="contact">
+          <div className="rounded-[3rem] border border-white/10 bg-gradient-to-br from-white/10 to-white/5 p-10 shadow-[0_25px_100px_rgba(8,145,178,0.18)]">
+            <div className="grid gap-10 lg:grid-cols-[1.2fr_1fr]">
+              <div className="space-y-6">
+                <p className="text-sm uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Demande rapide</p>
+                <h2 className="text-4xl font-extrabold leading-tight">
+                  90 secondes suffisent pour lancer un échange avec nos équipes.
+                </h2>
+                <div className="grid gap-4 text-sm text-slate-200/80">
+                  <div className="rounded-3xl border border-white/10 bg-white/5 p-5">
+                    <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/60 visual-accent-text">Analyse initiale</p>
+                    <p className="mt-2">Objectifs, publics cibles et formats souhaités : nous collectons les informations essentielles pour préparer la proposition.</p>
+                  </div>
+                  <div className="rounded-3xl border border-white/10 bg-white/5 p-5">
+                    <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/60 visual-accent-text">Coordination interne</p>
+                    <p className="mt-2">Le brief est partagé avec le pôle création, l'équipe plateau et notre cellule IA pour une réponse argumentée et chiffrée.</p>
+                  </div>
+                </div>
+              </div>
+              <form
+                className="space-y-4"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  recordContactRequest(form);
+                  setContactSent(true);
+                  setForm({ name: "", email: "", projectSpark: "", urgency: "hier" });
+                }}
+              >
+                <div>
+                  <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Nom / pseudo</label>
+                  <input
+                    required
+                    value={form.name}
+                    onChange={(event) => setForm((prev) => ({ ...prev, name: event.target.value }))}
+                    className="mt-2 w-full rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-white placeholder:text-slate-300/60 focus:border-cyan-400 visual-accent-border focus:outline-none"
+                    placeholder="Nom et prénom"
+                  />
+                </div>
+                <div>
+                  <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Email</label>
+                  <input
+                    type="email"
+                    required
+                    value={form.email}
+                    onChange={(event) => setForm((prev) => ({ ...prev, email: event.target.value }))}
+                    className="mt-2 w-full rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-white placeholder:text-slate-300/60 focus:border-cyan-400 visual-accent-border focus:outline-none"
+                    placeholder="vous@futurebrand.com"
+                  />
+                </div>
+                <div>
+                  <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Étincelle</label>
+                  <textarea
+                    required
+                    value={form.projectSpark}
+                    onChange={(event) => setForm((prev) => ({ ...prev, projectSpark: event.target.value }))}
+                    rows={4}
+                    className="mt-2 w-full rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-white placeholder:text-slate-300/60 focus:border-cyan-400 visual-accent-border focus:outline-none"
+                    placeholder="Décrivez le contexte, les objectifs et les livrables attendus"
+                  />
+                </div>
+                <div>
+                  <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Urgence</label>
+                  <select
+                    value={form.urgency}
+                    onChange={(event) => setForm((prev) => ({ ...prev, urgency: event.target.value as typeof form.urgency }))}
+                    className="mt-2 w-full rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                  >
+                    <option value="hier">Projet urgent</option>
+                    <option value="cette-semaine">Démarrage sous 7 jours</option>
+                    <option value="quand-c-est-parfait">Planifié</option>
+                  </select>
+                </div>
+                <button
+                  type="submit"
+                  className="group relative w-full overflow-hidden rounded-full border border-cyan-200/40 visual-accent-border bg-cyan-500/20 visual-accent-bg px-6 py-3 text-sm font-bold uppercase tracking-[0.3em] text-white"
+                >
+                  <span className="relative z-10">Envoyer ma demande</span>
+                  <span className="absolute inset-0 translate-x-[-120%] bg-gradient-to-r from-cyan-400 via-sky-300 to-fuchsia-400 visual-accent-gradient transition-transform duration-700 group-hover:translate-x-0 visual-accent-gradient" />
+                </button>
+                {contactSent && (
+                  <p className="rounded-2xl border border-cyan-200/30 visual-accent-border bg-cyan-500/10 visual-accent-chip px-4 py-3 text-sm text-cyan-100 visual-accent-text-strong">
+                    Merci pour votre message. Un membre de l'équipe Studio VBG revient vers vous sous 2 heures ouvrées.
+                  </p>
+                )}
+              </form>
+            </div>
+          </div>
+        </section>
+
+        <footer className="mx-auto max-w-6xl px-6 pb-16">
+          <div className="rounded-[2.5rem] border border-white/10 bg-white/5 p-10 text-sm text-slate-200/70">
+            <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+              <div>
+                <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Studio VBG</p>
+                <p className="mt-2 text-lg text-white">Agence de production, captation vidéo, création de contenus réseaux sociaux.</p>
+              </div>
+              <div className="flex gap-4 text-xs uppercase tracking-[0.3em] text-slate-300/80">
+                <Link to="/process" className="hover:text-white">Méthode</Link>
+                <Link to="/services" className="hover:text-white">Services</Link>
+                <Link to="/dashboard" className="hover:text-white">Dashboard</Link>
+              </div>
+              <div className="text-xs text-slate-300/80">
+                © {new Date().getFullYear()} Studio VBG · Pipeline propulsé par l'IA et une gestion de projet rigoureuse.
+              </div>
+            </div>
+          </div>
+        </footer>
       </div>
     </div>
   );

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,4 +1,4 @@
-import { useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { useEffect } from "react";
 
 const NotFound = () => {
@@ -9,13 +9,27 @@ const NotFound = () => {
   }, [location.pathname]);
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-100">
-      <div className="text-center">
-        <h1 className="mb-4 text-4xl font-bold">404</h1>
-        <p className="mb-4 text-xl text-gray-600">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 underline hover:text-blue-700">
-          Return to Home
-        </a>
+    <div className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden bg-slate-950 text-white">
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{ background: "radial-gradient(circle at top, hsla(var(--visual-secondary)/0.2), transparent 60%)" }}
+      />
+      <div
+        className="pointer-events-none absolute inset-0 animate-[spin_30s_linear_infinite]"
+        style={{ background: "conic-gradient(from 45deg, hsla(var(--visual-accent)/0.15), transparent 60%)" }}
+      />
+      <div className="relative max-w-xl space-y-6 rounded-[3rem] border border-white/10 bg-white/5 p-12 text-center shadow-[0_20px_120px_rgba(56,189,248,0.2)] visual-accent-veil">
+        <span className="text-xs uppercase tracking-[0.35em] text-cyan-100/80 visual-accent-text-strong">Erreur 404</span>
+        <h1 className="text-5xl font-black">Page non disponible</h1>
+        <p className="text-lg text-slate-200/80">
+          L'adresse demandée n'existe pas ou plus. Retournez à l'accueil pour poursuivre votre navigation.
+        </p>
+        <Link
+          to="/"
+          className="inline-flex items-center gap-3 rounded-full border border-cyan-200/40 visual-accent-border bg-cyan-500/20 visual-accent-bg px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white"
+        >
+          Retour à l'accueil
+        </Link>
       </div>
     </div>
   );

--- a/src/pages/Playground.tsx
+++ b/src/pages/Playground.tsx
@@ -1,0 +1,149 @@
+import { useState } from "react";
+
+const labs = [
+  {
+    id: "midjourney",
+    title: "Midjourney V7 - Prompt Lab",
+    punchline: "Des moodboards précis pour convaincre vos comités de direction.",
+    description:
+      "Moodboards générés, recolorisés et animés. Nous combinons prompts narratifs et contraintes de marque pour livrer des planches immédiatement exploitables en comité.",
+    upgrades: [
+      "Variations dédiées par persona",
+      "Palette synchronisée à votre brandbook",
+      "Export storyboard animé en 45 secondes",
+    ],
+    gradient: "radial-gradient(circle at top, hsla(var(--visual-accent-soft)/0.3), transparent 70%)",
+  },
+  {
+    id: "kling",
+    title: "Kling 2.5 - Volumetric Stage",
+    punchline: "Visualisez votre plateau avant la réservation des décors.",
+    description:
+      "Prévisualisation 3D, trajectoires caméra automatisées et éclairage calculé par IA pour valider les choix techniques avant production.",
+    upgrades: [
+      "Pathfinding caméra autonome",
+      "Simulation lumière temps réel",
+      "Export plan de tournage détaillé",
+    ],
+    gradient: "radial-gradient(circle at bottom left, hsla(var(--visual-secondary)/0.25), transparent 70%)",
+  },
+  {
+    id: "seedance",
+    title: "Seedance Pro - Choreo Engine",
+    punchline: "Synchronisez vos caméras avec un pilotage IA fiable.",
+    description:
+      "Seedance anticipe les mouvements, règle le tempo et propose des trajectoires caméra optimisées pour ne manquer aucune séquence clé.",
+    upgrades: [
+      "Pré-visualisation motion capture",
+      "Macro Atem scriptée en live",
+      "Export plan chorégraphique PDF + audio guide",
+    ],
+    gradient: "radial-gradient(circle at 80% 30%, hsla(var(--visual-tertiary)/0.22), transparent 70%)",
+  },
+  {
+    id: "veo",
+    title: "Veo 3 - Post-production AI",
+    punchline: "Un pipeline postproduction unifié pour accélérer vos livrables.",
+    description:
+      "L'IA synchronise les points de montage, génère les transitions, ajuste vos LUTs et prépare les exports multi-format en parallèle.",
+    upgrades: [
+      "Timeline multivers en un clic",
+      "Détection automatique des moments clés",
+      "Livraison 9:16 optimisée en 30 min",
+    ],
+    gradient: "radial-gradient(circle at 20% 80%, hsla(var(--visual-secondary)/0.24), transparent 70%)",
+  },
+];
+
+const Playground = () => {
+  const [selected, setSelected] = useState(labs[0]);
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-white">
+      <div
+        className="pointer-events-none absolute inset-0 animate-[spin_30s_linear_infinite]"
+        style={{
+          background:
+            "conic-gradient(from 0deg, hsla(var(--visual-accent)/0.12), transparent 60%, hsla(var(--visual-secondary)/0.12))",
+        }}
+      />
+      <div className="relative mx-auto max-w-6xl px-6 pb-32 pt-28">
+        <header className="rounded-[3rem] border border-white/10 bg-white/5 p-12 shadow-[0_20px_120px_rgba(14,165,233,0.2)] visual-accent-veil">
+          <div className="flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
+            <div className="max-w-3xl space-y-6">
+              <span className="inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.35em] text-cyan-100/80 visual-accent-text-strong">
+                Playground IA & R&D
+              </span>
+              <h1 className="text-5xl font-black leading-tight">Nos laboratoires pour hybrider réel et IA</h1>
+              <p className="text-lg text-slate-200/80">
+                Nous testons en continu de nouveaux workflows : prompts avancés, lip-sync automatisé et caméras autonomes. Objectif : des tournages fluides et des livrables fiables.
+              </p>
+            </div>
+            <div className="rounded-[2.5rem] border border-white/10 bg-white/10 p-8 text-sm text-slate-200/80">
+              <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Mise à jour</p>
+              <p className="mt-3 text-white">Version septembre 2025 : compatibilité Suno AI 2.0 et workflow Kling 2.5 en direct.</p>
+            </div>
+          </div>
+        </header>
+
+        <section className="mt-16 grid gap-10 lg:grid-cols-[0.7fr_1.3fr]">
+          <div className="rounded-[2.5rem] border border-white/10 bg-white/5 p-6">
+            <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Choisissez votre terrain de jeu</p>
+            <div className="mt-6 grid gap-3">
+              {labs.map((lab) => (
+                <button
+                  key={lab.id}
+                  type="button"
+                  onClick={() => setSelected(lab)}
+                  className={`group relative overflow-hidden rounded-2xl border border-white/10 px-5 py-4 text-left transition-all ${
+                    selected.id === lab.id ? "border-cyan-300 bg-white/15" : "bg-white/5 hover:bg-white/10"
+                  }`}
+                >
+                  <span
+                    className="absolute inset-0 -z-10 opacity-0 transition-opacity duration-500 group-hover:opacity-100"
+                    style={{
+                      background:
+                        "linear-gradient(120deg, hsla(var(--visual-accent)/0.25), hsla(var(--visual-secondary)/0.2))",
+                    }}
+                  />
+                  <p className="text-sm font-semibold text-white">{lab.title}</p>
+                  <p className="text-xs text-slate-200/70">{lab.punchline}</p>
+                </button>
+              ))}
+            </div>
+            <div className="mt-8 rounded-2xl border border-white/10 bg-white/5 p-4 text-xs text-slate-200/70">
+              <p className="uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Suivi</p>
+              <p className="mt-2">Chaque expérimentation documentée est partagée avec nos clients afin d'alimenter leurs futures productions.</p>
+            </div>
+          </div>
+          <div
+            className="relative overflow-hidden rounded-[3rem] border border-white/10 bg-white/5 p-12 shadow-[0_20px_120px_rgba(56,189,248,0.18)] visual-accent-veil"
+            style={{ backgroundImage: selected.gradient }}
+          >
+            <div className="relative space-y-8">
+              <div className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Lab actif</div>
+              <h2 className="text-4xl font-extrabold">{selected.title}</h2>
+              <p className="text-lg text-slate-200/80">{selected.description}</p>
+              <div className="grid gap-4 text-sm text-slate-200/80 sm:grid-cols-2">
+                {selected.upgrades.map((item) => (
+                  <div key={item} className="rounded-3xl border border-white/10 bg-white/10 p-5">
+                    <p className="flex items-center gap-3 text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">
+                      <span className="h-2 w-2 rounded-full bg-cyan-300 visual-accent-dot" /> Upgrade
+                    </p>
+                    <p className="mt-3">{item}</p>
+                  </div>
+                ))}
+              </div>
+              <div className="rounded-[2.5rem] border border-white/10 bg-white/5 p-6 text-sm text-slate-200/70">
+                <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Support continu</p>
+                <p className="mt-2">Une équipe dédiée accompagne chaque expérimentation pour assurer la transition vers vos projets clients.</p>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default Playground;

--- a/src/pages/Portfolio.tsx
+++ b/src/pages/Portfolio.tsx
@@ -1,0 +1,267 @@
+import { useMemo, useState, useCallback } from "react";
+import { Link } from "react-router-dom";
+import { useStudio, type PortfolioItem } from "@/context/StudioContext";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+const Portfolio = () => {
+  const { portfolioItems, serviceCategories } = useStudio();
+  const categories = useMemo(() => ["Tous", ...serviceCategories], [serviceCategories]);
+  const [filter, setFilter] = useState("Tous");
+  const [activeProject, setActiveProject] = useState<PortfolioItem | null>(null);
+  const highlightProject = useMemo(
+    () =>
+      (filter === "Tous" ? portfolioItems[0] : portfolioItems.find((item) => item.category === filter)) ||
+      portfolioItems[0],
+    [filter, portfolioItems],
+  );
+
+  const getEmbedUrl = useCallback((url: string) => {
+    const match = url.match(/(?:v=|youtu\.be\/|embed\/)([A-Za-z0-9_-]{11})/);
+    if (match?.[1]) {
+      return `https://www.youtube.com/embed/${match[1]}?rel=0&modestbranding=1`;
+    }
+    return url;
+  }, []);
+
+  const filtered = useMemo(
+    () =>
+      filter === "Tous"
+        ? portfolioItems
+        : portfolioItems.filter((item) => item.category === filter),
+    [filter, portfolioItems],
+  );
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-white">
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{ background: "radial-gradient(circle at 10% 15%, hsla(var(--visual-accent)/0.35), transparent 55%)" }}
+      />
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{ background: "radial-gradient(circle at 90% 85%, hsla(var(--visual-secondary)/0.25), transparent 50%)" }}
+      />
+      <div className="relative mx-auto max-w-7xl px-6 pb-28 pt-24">
+        <section className="overflow-hidden rounded-[3.5rem] border border-white/10 bg-gradient-to-br from-white/10 via-slate-950/40 to-slate-950/80 p-12 shadow-[0_45px_140px_rgba(56,189,248,0.22)] visual-accent-halo">
+          <div className="grid gap-12 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
+            <div className="space-y-7">
+              <span className="inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.35em] text-cyan-100/80 visual-accent-text-strong">
+                Studio VBG Originals
+              </span>
+              <h1 className="text-4xl font-black leading-tight sm:text-5xl">
+                Des références vidéo pilotées par l'IA et la production terrain
+              </h1>
+              <p className="text-base text-slate-200/85 sm:text-lg">
+                Chaque projet illustre notre maîtrise des tournages premium et des optimisations IA. Tous les éléments peuvent être mis à jour, archivés ou dupliqués depuis le tableau de bord.
+              </p>
+              <div className="flex flex-wrap gap-4">
+                <Link
+                  to="/quote"
+                  className="inline-flex items-center gap-3 rounded-full border border-transparent bg-gradient-to-r from-cyan-400/80 via-fuchsia-500/80 to-amber-400/80 px-6 py-3 text-xs font-bold uppercase tracking-[0.4em] text-slate-950 shadow-lg shadow-cyan-400/40 transition hover:scale-[1.03]"
+                >
+                  Demander un devis
+                </Link>
+                <Link
+                  to="/contact"
+                  className="inline-flex items-center gap-3 rounded-full border border-white/20 bg-white/10 px-6 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/15"
+                >
+                  Contact rapide
+                </Link>
+              </div>
+              <p className="text-[11px] uppercase tracking-[0.4em] text-cyan-200/70 visual-accent-text">
+                Kling 2.5 · Midjourney V7 · Seedance Pro · Veo 3 · Suno AI
+              </p>
+            </div>
+            <div className="relative">
+              <div className="absolute -left-14 -top-14 h-24 w-24 rounded-full bg-cyan-400/30 blur-3xl" />
+              <div className="absolute -bottom-10 -right-16 h-32 w-32 rounded-full bg-fuchsia-500/20 blur-3xl" />
+              <div className="relative overflow-hidden rounded-[3rem] border border-white/10 bg-black/40 shadow-[0_35px_120px_rgba(14,165,233,0.35)]">
+                {highlightProject ? (
+                  <>
+                    <img
+                      src={highlightProject.thumbnail}
+                      alt={highlightProject.title}
+                      className="h-[22rem] w-full object-cover object-center"
+                    />
+                    <div className="absolute inset-0 bg-gradient-to-t from-slate-950/90 via-slate-950/20 to-transparent" />
+                    <div className="absolute bottom-8 left-8 right-8 space-y-3">
+                      <p className="text-[10px] uppercase tracking-[0.4em] text-cyan-200/70 visual-accent-text">{highlightProject.category}</p>
+                      <h2 className="text-2xl font-bold text-white">{highlightProject.title}</h2>
+                      <p className="text-xs text-slate-200/80">{highlightProject.tagline}</p>
+                    </div>
+                  </>
+                ) : (
+                  <div className="flex h-[22rem] items-center justify-center bg-slate-900/60 text-sm text-slate-400">
+                    Ajoutez un projet depuis le tableau de bord pour activer cet aperçu.
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="mt-20">
+          <nav className="flex flex-wrap items-center gap-3 text-[11px] font-semibold uppercase tracking-[0.35em]">
+            {categories.map((category) => {
+              const isActive = filter === category;
+              return (
+                <button
+                  key={category}
+                  type="button"
+                  onClick={() => setFilter(category)}
+                  className={`rounded-full px-5 py-2 transition ${
+                    isActive
+                      ? "bg-gradient-to-r from-cyan-400/40 via-fuchsia-500/40 to-amber-400/40 text-white shadow-[0_0_0_1px_rgba(255,255,255,0.15)]"
+                      : "border border-white/15 bg-white/5 text-slate-200/70 hover:bg-white/10"
+                  }`}
+                >
+                  {category}
+                </button>
+              );
+            })}
+          </nav>
+
+          <div className="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+            {filtered.map((project) => (
+              <article
+                key={project.id}
+                role="button"
+                tabIndex={0}
+                onClick={() => setActiveProject(project)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    setActiveProject(project);
+                  }
+                }}
+                className="group relative overflow-hidden rounded-[2.75rem] border border-white/10 bg-white/5 shadow-[0_25px_120px_rgba(56,189,248,0.2)] transition-transform duration-500 hover:-translate-y-1 focus:outline-none focus:ring-2 focus:ring-cyan-300/60"
+              >
+                <div className="relative h-52 overflow-hidden">
+                  <img src={project.thumbnail} alt={project.title} className="h-full w-full object-cover object-center" />
+                  <div className="absolute inset-0 bg-gradient-to-t from-slate-950/90 via-slate-950/15 to-transparent transition-opacity duration-500 group-hover:opacity-90" />
+                  <div className="absolute left-6 right-6 bottom-6 space-y-2">
+                    <p className="text-[10px] uppercase tracking-[0.35em] text-cyan-200/70 visual-accent-text">{project.category}</p>
+                    <h2 className="text-xl font-semibold text-white">{project.title}</h2>
+                    <p className="text-xs text-slate-200/75">{project.tagline}</p>
+                  </div>
+                </div>
+                <div className="space-y-4 px-6 pb-6 pt-5 text-xs text-slate-200/75">
+                  <div className="flex items-center justify-between text-[10px] uppercase tracking-[0.35em] text-slate-200/60">
+                    <span>{project.year}</span>
+                    <span>{project.duration}</span>
+                  </div>
+                  <div className="flex flex-wrap gap-2 text-[11px] text-cyan-100/75 visual-accent-text-strong">
+                    {project.aiTools.slice(0, 3).map((tool) => (
+                      <span key={tool} className="rounded-full bg-cyan-500/10 visual-accent-chip px-3 py-1">
+                        {tool}
+                      </span>
+                    ))}
+                    {project.aiTools.length > 3 && (
+                      <span className="rounded-full border border-white/15 px-3 py-1">+{project.aiTools.length - 3}</span>
+                    )}
+                  </div>
+                  <div className="text-[11px] uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Diffusions</div>
+                  <div className="flex flex-wrap gap-2 text-[11px]">
+                    {project.socialStack.map((channel) => (
+                      <span key={channel} className="rounded-full border border-white/15 bg-white/5 px-3 py-1">
+                        {channel}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+                <div className="absolute inset-0 hidden items-center justify-center bg-slate-950/70 text-[11px] uppercase tracking-[0.35em] text-white backdrop-blur-md transition group-hover:flex">
+                  Ouvrir la fiche
+                </div>
+              </article>
+            ))}
+          </div>
+
+          {filtered.length === 0 && (
+            <div className="mt-16 rounded-[3.25rem] border border-white/10 bg-white/10 p-12 text-center text-sm text-slate-200/70">
+              <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Aucun projet pour l'instant</p>
+              <p className="mt-4 text-2xl text-white">Ajoutez une nouvelle réalisation depuis le tableau de bord pour alimenter cette catégorie.</p>
+              <Link
+                to="/dashboard"
+                className="mt-6 inline-flex items-center gap-3 rounded-full border border-cyan-200/40 visual-accent-border bg-cyan-500/20 visual-accent-bg px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white"
+              >
+                Ajouter un projet
+              </Link>
+            </div>
+          )}
+        </section>
+
+        <Dialog open={Boolean(activeProject)} onOpenChange={(open) => !open && setActiveProject(null)}>
+          <DialogContent className="max-w-4xl border border-white/10 bg-slate-950/95 text-white backdrop-blur">
+            {activeProject && (
+              <div className="space-y-8">
+                <DialogHeader className="space-y-3 text-left">
+                  <DialogTitle className="text-3xl font-bold text-white">{activeProject.title}</DialogTitle>
+                  <DialogDescription className="text-sm uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">
+                    {activeProject.category} · {activeProject.duration} · {activeProject.year}
+                  </DialogDescription>
+                  <p className="text-base text-slate-200/80">{activeProject.tagline}</p>
+                </DialogHeader>
+                <div className="grid gap-6 lg:grid-cols-[1.3fr_0.7fr]">
+                  <div className="space-y-4">
+                    <div className="aspect-video overflow-hidden rounded-[2.5rem] border border-white/10 bg-black">
+                      <iframe
+                        src={getEmbedUrl(activeProject.videoUrl)}
+                        title={activeProject.title}
+                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                        allowFullScreen
+                        className="h-full w-full"
+                      />
+                    </div>
+                    <p className="whitespace-pre-line text-sm leading-relaxed text-slate-200/80">
+                      {activeProject.description}
+                    </p>
+                  </div>
+                  <aside className="space-y-5 rounded-[2.5rem] border border-white/10 bg-white/5 p-6 text-sm text-slate-200/80">
+                    <div>
+                      <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Pipeline IA</p>
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        {activeProject.aiTools.map((tool) => (
+                          <span key={tool} className="rounded-full bg-cyan-500/10 visual-accent-chip px-3 py-1 text-xs text-cyan-100/80">
+                            {tool}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                    <div>
+                      <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Livrables</p>
+                      <ul className="mt-2 space-y-2">
+                        {activeProject.deliverables.map((deliverable) => (
+                          <li key={deliverable} className="flex items-center gap-3 text-xs">
+                            <span className="h-2 w-2 rounded-full bg-cyan-300 visual-accent-dot" /> {deliverable}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                    <div>
+                      <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Diffusions</p>
+                      <div className="mt-2 flex flex-wrap gap-2 text-xs">
+                        {activeProject.socialStack.map((channel) => (
+                          <span key={channel} className="rounded-full border border-white/20 bg-white/10 px-3 py-1">
+                            {channel}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  </aside>
+                </div>
+              </div>
+            )}
+          </DialogContent>
+        </Dialog>
+      </div>
+    </div>
+  );
+};
+
+export default Portfolio;

--- a/src/pages/Process.tsx
+++ b/src/pages/Process.tsx
@@ -1,0 +1,101 @@
+const timeline = [
+  {
+    id: "brief",
+    title: "Brief initial",
+    description:
+      "Nous analysons votre contexte, vos objectifs et vos audiences. Notre IA priorise les informations clés et structure les premières pistes créatives.",
+    gradient: "radial-gradient(circle at top, hsla(var(--visual-accent)/0.25), transparent 70%)",
+  },
+  {
+    id: "design",
+    title: "Conception narrative",
+    description:
+      "Moodboards Midjourney V7, scripts générés et découpage technique. Chaque séquence est associée à un objectif précis et à des indicateurs de performance.",
+    gradient: "radial-gradient(circle at 60% 20%, hsla(var(--visual-secondary)/0.28), transparent 70%)",
+  },
+  {
+    id: "shoot",
+    title: "Production",
+    description:
+      "Seedance Pro anticipe les mouvements caméra, Kling 2.5 projette les décors et nos équipes plateau pilotent chaque séquence avec précision.",
+    gradient: "radial-gradient(circle at 30% 80%, hsla(var(--visual-tertiary)/0.24), transparent 70%)",
+  },
+  {
+    id: "post",
+    title: "Postproduction",
+    description:
+      "Veo 3 accélère le montage, Davinci assure la colorimétrie, Suno AI compose le sound design et LypSync V2 harmonise les voix.",
+    gradient: "radial-gradient(circle at bottom right, hsla(var(--visual-accent-soft)/0.24), transparent 70%)",
+  },
+  {
+    id: "launch",
+    title: "Diffusion",
+    description:
+      "Nous publions, suivons la performance et ajustons les formats. Les reportings sont partagés en temps réel via le tableau de bord.",
+    gradient: "radial-gradient(circle at 50% 50%, hsla(var(--visual-secondary)/0.22), transparent 70%)",
+  },
+];
+
+const Process = () => {
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-white">
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background:
+            "conic-gradient(from 60deg at 50% 50%, hsla(var(--visual-accent)/0.22), transparent 70%)",
+        }}
+      />
+      <div className="relative mx-auto max-w-6xl px-6 pb-32 pt-28">
+        <header className="rounded-[3rem] border border-white/10 bg-white/5 p-12 shadow-[0_20px_120px_rgba(14,165,233,0.2)] visual-accent-veil">
+          <div className="space-y-6">
+            <span className="inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.35em] text-cyan-100/80 visual-accent-text-strong">
+              Processus Studio VBG
+            </span>
+            <h1 className="text-5xl font-black leading-tight">Notre méthodologie de production vidéo</h1>
+            <p className="text-lg text-slate-200/80">
+              De la définition du brief à la diffusion, chaque étape est orchestrée pour garantir une qualité constante et une visibilité complète sur l'avancement.
+            </p>
+          </div>
+        </header>
+
+        <section className="mt-16 space-y-12">
+          {timeline.map((step, index) => (
+            <article
+              key={step.id}
+              className="relative overflow-hidden rounded-[3rem] border border-white/10 bg-white/5 p-10 shadow-[0_20px_110px_rgba(56,189,248,0.15)] visual-accent-veil"
+              style={{ backgroundImage: step.gradient }}
+            >
+              <span className="absolute left-12 top-8 text-6xl font-black text-white/10">0{index + 1}</span>
+              <div className="relative grid gap-6 lg:grid-cols-[1.2fr_1fr]">
+                <div className="space-y-4">
+                  <h2 className="text-3xl font-extrabold">{step.title}</h2>
+                  <p className="text-lg text-slate-200/80">{step.description}</p>
+                </div>
+                <div className="rounded-[2.5rem] border border-white/10 bg-white/10 p-6 text-sm text-slate-200/70">
+                  <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Livrables associés</p>
+                  <p className="mt-3">
+                    {index === 0 && "Compte rendu synthétique, plan d'action initial et échéancier partagé."}
+                    {index === 1 && "Scénario validé, moodboards, prévisualisations et planning de tournage."}
+                    {index === 2 && "Feuilles de service, captations sécurisées, rushes organisés et backups."}
+                    {index === 3 && "Montages intermédiaires, validations collaboratives et exports multi-plateformes."}
+                    {index === 4 && "Calendrier de diffusion, reporting de performance et recommandations d'optimisation."}
+                  </p>
+                </div>
+              </div>
+            </article>
+          ))}
+        </section>
+
+        <section className="mt-16 rounded-[3rem] border border-white/10 bg-white/5 p-12 text-center text-sm text-slate-200/70">
+          <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Prêt à collaborer ?</p>
+          <p className="mt-6 text-3xl font-semibold text-white">
+            Connectez-vous, partagez votre brief et nous lançons la production dans les meilleurs délais.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default Process;

--- a/src/pages/QuoteBuilder.tsx
+++ b/src/pages/QuoteBuilder.tsx
@@ -1,0 +1,217 @@
+import { FormEvent, useState } from "react";
+import { Link } from "react-router-dom";
+import { useStudio } from "@/context/StudioContext";
+
+const availableServices = [
+  "Captation multicam",
+  "Scénarisation assistée par IA",
+  "Plateau XR",
+  "Pack réseaux sociaux",
+  "Diffusion live",
+  "Contenus verticaux 9:16",
+];
+
+const QuoteBuilder = () => {
+  const { user, createQuoteRequest } = useStudio();
+  const [step, setStep] = useState(0);
+  const [successId, setSuccessId] = useState<string | null>(null);
+  const [form, setForm] = useState({
+    projectName: "",
+    budgetRange: "",
+    deadline: "",
+    services: [] as string[],
+    moodboardPrompt: "",
+  });
+
+  if (!user) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center bg-slate-950 px-6 text-center text-white">
+        <div className="max-w-xl space-y-6 rounded-[3rem] border border-white/10 bg-white/5 p-12">
+          <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Étape obligatoire</p>
+          <h1 className="text-4xl font-black leading-tight">Connectez-vous avant de demander un devis</h1>
+          <p className="text-lg text-slate-200/80">
+            Une fois votre compte actif, vous accédez au tableau de bord et au suivi en temps réel de votre dossier.
+          </p>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link to="/auth" className="rounded-full border border-cyan-200/40 visual-accent-border bg-cyan-500/20 visual-accent-bg px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white">
+              Me connecter
+            </Link>
+            <Link to="/" className="rounded-full border border-white/30 bg-white/10 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white">
+              Explorer avant
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const quote = createQuoteRequest(form);
+    if (quote) {
+      setSuccessId(quote.id);
+    }
+  };
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-white">
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{ background: "radial-gradient(circle at 15% 15%, hsla(var(--visual-accent)/0.22), transparent 60%)" }}
+      />
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{ background: "radial-gradient(circle at 85% 85%, hsla(var(--visual-secondary)/0.22), transparent 60%)" }}
+      />
+      <div className="relative mx-auto max-w-5xl px-6 pb-32 pt-28">
+        <header className="rounded-[3rem] border border-white/10 bg-white/5 p-12 shadow-[0_20px_120px_rgba(14,165,233,0.2)] visual-accent-veil">
+          <div className="flex flex-col gap-6">
+            <span className="inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.35em] text-cyan-100/80 visual-accent-text-strong">
+              Demande de devis · Studio VBG
+            </span>
+            <h1 className="text-5xl font-black leading-tight">Construisons votre projet vidéo</h1>
+            <p className="text-lg text-slate-200/80">
+              Trois étapes guidées : notre IA synthétise votre brief pour préparer le travail des équipes de production.
+            </p>
+          </div>
+        </header>
+
+        <form onSubmit={handleSubmit} className="mt-16 space-y-8 rounded-[3rem] border border-white/10 bg-white/10 p-10 shadow-[0_20px_100px_rgba(236,72,153,0.2)] visual-secondary-veil">
+          <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-slate-200/70">
+            <span>Étape {step + 1} / 3</span>
+            <div className="flex gap-2">
+              {[0, 1, 2].map((index) => (
+                <span
+                  key={index}
+                  className={`h-1.5 w-16 rounded-full ${index <= step ? "bg-cyan-300 visual-accent-dot" : "bg-white/20"}`}
+                />
+              ))}
+            </div>
+          </div>
+
+          {step === 0 && (
+            <div className="space-y-4">
+              <div>
+                <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Nom du projet</label>
+                <input
+                  className="mt-2 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                  value={form.projectName}
+                  onChange={(event) => setForm((prev) => ({ ...prev, projectName: event.target.value }))}
+                  placeholder="Nom du projet"
+                  required
+                />
+              </div>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div>
+                  <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Budget pressenti</label>
+                  <input
+                    className="mt-2 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                    value={form.budgetRange}
+                    onChange={(event) => setForm((prev) => ({ ...prev, budgetRange: event.target.value }))}
+                    placeholder="15 000 € - 25 000 €"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Deadline</label>
+                  <input
+                    type="date"
+                    className="mt-2 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                    value={form.deadline}
+                    onChange={(event) => setForm((prev) => ({ ...prev, deadline: event.target.value }))}
+                    required
+                  />
+                </div>
+              </div>
+            </div>
+          )}
+
+          {step === 1 && (
+            <div className="space-y-4">
+              <p className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Services souhaités</p>
+              <div className="grid gap-3 sm:grid-cols-2">
+                {availableServices.map((service) => {
+                  const active = form.services.includes(service);
+                  return (
+                    <button
+                      key={service}
+                      type="button"
+                      onClick={() =>
+                        setForm((prev) => ({
+                          ...prev,
+                          services: active
+                            ? prev.services.filter((item) => item !== service)
+                            : [...prev.services, service],
+                        }))
+                      }
+                      className={`rounded-2xl border px-4 py-3 text-left text-sm transition ${
+                        active ? "border-cyan-300 bg-white/20 text-white" : "border-white/20 bg-white/10 text-slate-200/80"
+                      }`}
+                    >
+                      {service}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {step === 2 && (
+            <div className="space-y-4">
+              <div>
+                <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Moodboard & intentions</label>
+                <textarea
+                  className="mt-2 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                  rows={6}
+                  value={form.moodboardPrompt}
+                  onChange={(event) => setForm((prev) => ({ ...prev, moodboardPrompt: event.target.value }))}
+                  placeholder="Décrivez les enjeux, les messages prioritaires et les livrables attendus."
+                  required
+                />
+              </div>
+              <p className="text-xs text-slate-200/60">
+                Notre IA transforme ce brief en storyboard, sélection d'actifs et planning prévisionnel.
+              </p>
+            </div>
+          )}
+
+          <div className="flex justify-between pt-4">
+            <button
+              type="button"
+              onClick={() => setStep((prev) => Math.max(prev - 1, 0))}
+              className="rounded-full border border-white/30 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white disabled:opacity-40"
+              disabled={step === 0}
+            >
+              Retour
+            </button>
+            {step < 2 ? (
+              <button
+                type="button"
+                onClick={() => setStep((prev) => Math.min(prev + 1, 2))}
+                className="rounded-full border border-cyan-200/40 visual-accent-border bg-cyan-500/20 visual-accent-bg px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white"
+              >
+                Étape suivante
+              </button>
+            ) : (
+              <button
+                type="submit"
+                className="group relative overflow-hidden rounded-full border border-cyan-200/40 visual-accent-border bg-cyan-500/20 visual-accent-bg px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white"
+              >
+                <span className="relative z-10">Envoyer le brief</span>
+                <span className="absolute inset-0 translate-x-[-120%] bg-gradient-to-r from-cyan-400 via-sky-300 to-fuchsia-400 transition-transform duration-700 group-hover:translate-x-0 visual-accent-gradient" />
+              </button>
+            )}
+          </div>
+
+          {successId && (
+            <div className="rounded-3xl border border-emerald-200/40 bg-emerald-500/10 p-6 text-sm text-emerald-100">
+              Votre demande est enregistrée. Un espace de discussion dédié s'ouvrira dès validation du devis. ID : {successId.slice(0, 8)}...
+            </div>
+          )}
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default QuoteBuilder;

--- a/src/pages/ServiceDetail.tsx
+++ b/src/pages/ServiceDetail.tsx
@@ -1,0 +1,114 @@
+import { Link, useParams } from "react-router-dom";
+import { servicesData } from "@/lib/services";
+
+const ServiceDetail = () => {
+  const { slug } = useParams();
+  const service = servicesData.find((item) => item.slug === slug);
+
+  if (!service) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center bg-slate-950 text-white">
+        <p className="text-sm uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Service introuvable</p>
+        <h1 className="mt-4 text-4xl font-bold">Ce module n'est pas disponible pour le moment.</h1>
+        <Link to="/services" className="mt-8 rounded-full border border-cyan-200/40 visual-accent-border bg-cyan-500/20 visual-accent-bg px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white">
+          Retour aux services
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-white">
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background:
+            "conic-gradient(from 120deg at 20% 20%, hsla(var(--visual-accent)/0.25), hsla(var(--visual-secondary)/0.18), transparent 70%)",
+        }}
+      />
+      <div className="relative mx-auto max-w-6xl px-6 pb-24 pt-28">
+        <header className="rounded-[3rem] border border-white/10 bg-white/5 p-12 shadow-[0_20px_120px_rgba(34,211,238,0.2)] visual-accent-veil">
+          <div className="flex flex-col gap-10 lg:flex-row lg:items-end lg:justify-between">
+            <div className="space-y-6">
+              <span className="inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.35em] text-cyan-100/80 visual-accent-text-strong">
+                Module Studio VBG
+              </span>
+              <h1 className="text-5xl font-black">{service.title}</h1>
+              <p className="text-lg text-slate-200/80">{service.subtitle}</p>
+            </div>
+            <div className="text-sm text-slate-200/70">
+              <p className="uppercase tracking-[0.3em] text-cyan-200/80 visual-accent-text">Point différenciant</p>
+              <p className="mt-2 text-lg text-white">{service.signatureMove}</p>
+            </div>
+          </div>
+        </header>
+
+        <section className="mt-16 grid gap-12 lg:grid-cols-[1.5fr_1fr]">
+          <div className="space-y-10">
+            <div className="rounded-[2.5rem] border border-white/10 bg-white/5 p-10 shadow-[0_15px_80px_rgba(14,165,233,0.2)] visual-accent-glow">
+              <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Narration</p>
+              <p className="mt-4 text-lg leading-relaxed text-slate-200/80">{service.promise}</p>
+            </div>
+            <div className="space-y-6">
+              {service.phases.map((phase, index) => (
+                <div
+                  key={phase.title}
+                  className="group relative overflow-hidden rounded-[2.5rem] border border-white/10 bg-gradient-to-br from-white/10 to-white/5 p-8 shadow-[0_20px_90px_rgba(236,72,153,0.18)] visual-secondary-veil"
+                >
+                  <span className="absolute inset-0 translate-y-full bg-gradient-to-t from-fuchsia-500/20 via-transparent to-transparent transition-transform duration-700 group-hover:translate-y-0" />
+                  <div className="relative space-y-4">
+                    <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-slate-200/70">
+                      <span>Phase 0{index + 1}</span>
+                      <span>{phase.aiUpgrade}</span>
+                    </div>
+                    <h2 className="text-2xl font-bold">{phase.title}</h2>
+                    <p className="text-sm text-slate-200/80">{phase.description}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+          <aside className="space-y-8">
+            <div className="rounded-[2.5rem] border border-white/10 bg-white/5 p-8">
+              <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Livrables inclus</p>
+              <ul className="mt-4 space-y-3 text-sm text-slate-200/80">
+                {service.deliverables.map((item) => (
+                  <li key={item} className="flex items-start gap-3">
+                    <span className="mt-1 h-2 w-2 rounded-full bg-cyan-300 visual-accent-dot" />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div className="rounded-[2.5rem] border border-white/10 bg-white/5 p-8">
+              <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Chiffres clés</p>
+              <ul className="mt-4 space-y-4 text-sm text-slate-200/80">
+                {service.metrics.map((metric) => (
+                  <li key={metric.label} className="rounded-2xl bg-slate-900/60 p-4">
+                    <p className="text-xs uppercase tracking-[0.3em] text-slate-200/60">{metric.label}</p>
+                    <p className="mt-2 text-2xl font-bold text-cyan-200 visual-accent-text">{metric.value}</p>
+                    <p className="text-xs text-slate-200/60">{metric.note}</p>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div className="rounded-[2.5rem] border border-white/10 bg-white/5 p-8 text-sm text-slate-200/80">
+              <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Étape suivante</p>
+              <p className="mt-4">Intéressé par ce module ? Connectez-vous, demandez un devis et nous lançons la préproduction.</p>
+              <div className="mt-6 flex flex-col gap-3">
+                <Link to="/auth" className="rounded-full border border-white/30 bg-white/10 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white">
+                  Me connecter
+                </Link>
+                <Link to="/quote" className="rounded-full border border-cyan-200/40 visual-accent-border bg-cyan-500/20 visual-accent-bg px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white">
+                  Demander un devis
+                </Link>
+              </div>
+            </div>
+          </aside>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default ServiceDetail;

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -1,0 +1,134 @@
+import { Link } from "react-router-dom";
+import { servicesData } from "@/lib/services";
+
+const Services = () => {
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-white">
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{ background: "radial-gradient(circle at 10% 20%, hsla(var(--visual-accent)/0.35), transparent 60%)" }}
+      />
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{ background: "radial-gradient(circle at 80% 80%, hsla(var(--visual-secondary)/0.25), transparent 60%)" }}
+      />
+      <div className="relative mx-auto flex max-w-6xl flex-col gap-16 px-6 pb-32 pt-32">
+        <header className="rounded-[3rem] border border-white/10 bg-white/5 p-12 shadow-[0_25px_120px_rgba(14,165,233,0.2)] visual-accent-halo">
+          <div className="flex flex-col gap-10 lg:flex-row lg:items-center lg:justify-between">
+            <div className="max-w-3xl space-y-6">
+              <span className="inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.35em] text-cyan-100/80 visual-accent-text-strong">
+                Services Studio VBG · 2025
+              </span>
+              <h1 className="text-5xl font-black leading-tight">
+                Des offres structurées pour sécuriser vos productions vidéo
+              </h1>
+              <p className="text-lg text-slate-200/80">
+                Chaque module associe stratégie de contenu, innovation IA et savoir-faire de plateau afin de délivrer des expériences cohérentes et mesurables.
+              </p>
+            </div>
+            <div className="grid gap-4 text-sm text-slate-200/70">
+              <div className="rounded-3xl border border-white/10 bg-white/10 p-5">
+                <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Écosystème technologique</p>
+                <p className="mt-2">Midjourney V7 · Kling 2.5 · Seedance Pro · Veo 3 · Suno AI · LypSync V2</p>
+              </div>
+              <div className="rounded-3xl border border-white/10 bg-white/10 p-5">
+                <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Engagement projet</p>
+                <p className="mt-2">Chaque collaboration inclut un cadrage initial détaillé et des points d'étape documentés.</p>
+              </div>
+            </div>
+          </div>
+        </header>
+
+        <section className="grid gap-12">
+          {servicesData.map((service, index) => (
+            <article
+              key={service.slug}
+              className="relative overflow-hidden rounded-[3rem] border border-white/10 bg-gradient-to-br from-white/10 via-slate-900/40 to-slate-900/60 p-12 shadow-[0_20px_120px_rgba(59,130,246,0.18)]"
+            >
+              <span className="absolute inset-0 translate-x-[-100%] bg-gradient-to-r from-cyan-500/20 via-transparent to-transparent opacity-0 transition-all duration-700 hover:translate-x-0 hover:opacity-100 visual-accent-gradient" />
+              <div className="relative grid gap-8 lg:grid-cols-[1.5fr_1fr]">
+                <div className="space-y-6">
+                  <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-slate-200/70">
+                    <span>Module 0{index + 1}</span>
+                    <span>{service.signatureMove}</span>
+                  </div>
+                  <h2 className="text-4xl font-extrabold">{service.title}</h2>
+                  <p className="text-lg text-slate-200/80">{service.subtitle}</p>
+                  <div className="grid gap-4 text-sm text-slate-200/80 lg:grid-cols-2">
+                    <div className="rounded-3xl border border-white/10 bg-white/10 p-5">
+                      <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Problème</p>
+                      <p className="mt-2 leading-relaxed">{service.problem}</p>
+                    </div>
+                    <div className="rounded-3xl border border-white/10 bg-white/10 p-5">
+                      <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Promesse</p>
+                      <p className="mt-2 leading-relaxed">{service.promise}</p>
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap gap-3 text-xs uppercase tracking-[0.3em] text-cyan-100/80 visual-accent-text-strong">
+                    {service.stack.map((tool) => (
+                      <span key={tool} className="rounded-full border border-cyan-200/30 visual-accent-border bg-cyan-500/10 visual-accent-chip px-4 py-2">
+                        {tool}
+                      </span>
+                    ))}
+                  </div>
+                  <Link
+                    to={`/services/${service.slug}`}
+                    className="inline-flex items-center gap-3 rounded-full border border-white/20 bg-white/10 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white transition hover:bg-white/20"
+                  >
+                    Consulter le détail du service
+                  </Link>
+                </div>
+                <div className="space-y-6">
+                  <div className="rounded-3xl border border-white/10 bg-white/10 p-6">
+                    <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Livrables</p>
+                    <ul className="mt-4 space-y-2 text-sm text-slate-200/80">
+                      {service.deliverables.map((item) => (
+                        <li key={item} className="flex items-center gap-3">
+                          <span className="h-2 w-2 rounded-full bg-cyan-300 visual-accent-dot" /> {item}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                  <div className="rounded-3xl border border-white/10 bg-white/10 p-6">
+                    <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Chiffres clés</p>
+                    <ul className="mt-4 space-y-3 text-sm text-slate-200/80">
+                      {service.metrics.map((metric) => (
+                        <li key={metric.label} className="flex items-center justify-between rounded-2xl bg-slate-900/60 px-4 py-3">
+                          <span>{metric.label}</span>
+                          <span className="text-cyan-200 visual-accent-text">{metric.value}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+              </div>
+            </article>
+          ))}
+        </section>
+
+        <section className="rounded-[3rem] border border-white/10 bg-white/5 p-12 text-center text-sm text-slate-200/70">
+          <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Besoin d'un accompagnement hybride ?</p>
+          <p className="mt-6 text-3xl font-semibold text-white">
+            Nous composons une offre sur-mesure en combinant nos expertises de captation, d'IA et de diffusion.
+          </p>
+          <div className="mt-8 flex flex-wrap justify-center gap-4">
+            <Link
+              to="/quote"
+              className="rounded-full border border-cyan-200/30 visual-accent-border bg-cyan-500/20 visual-accent-bg px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white"
+            >
+              Demander un devis personnalisé
+            </Link>
+            <Link
+              to="/auth"
+              className="rounded-full border border-white/30 bg-white/10 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white"
+            >
+              Me connecter pour préparer le brief
+            </Link>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default Services;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
 
 export default {
   darkMode: ["class"],
@@ -87,5 +88,5 @@ export default {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [animatePlugin],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- Rewrite copy across the home, services, portfolio, process, playground and auth flows to adopt a professional tone while keeping the existing design
- Refresh seeded service metadata, navigation tooltips and portfolio entries in the studio context to align with the new messaging
- Update quote builder options and notifications for formal phrasing and adjust fallback pages accordingly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d49fa80124832892b62a2e86ccb317