### PR TITLE
Add hero button linking to authentication or dashboard

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -21,7 +21,7 @@ const techStack = [
 ];
 
 const Index = () => {
-  const { portfolioItems, recordContactRequest } = useStudio();
+  const { portfolioItems, recordContactRequest, user } = useStudio();
   const [hookIndex, setHookIndex] = useState(0);
   const [contactSent, setContactSent] = useState(false);
   const [form, setForm] = useState({
@@ -90,6 +90,16 @@ const Index = () => {
                 </span>
                 <span className="absolute inset-0 -z-0 translate-y-full bg-white/20 transition-all duration-500 group-hover:translate-y-0" />
               </a>
+              <Link
+                to={user ? "/dashboard" : "/auth"}
+                className="group relative overflow-hidden rounded-full border border-white/20 bg-white/10 px-8 py-4 text-sm font-bold uppercase tracking-[0.3em] text-white transition hover:scale-105"
+              >
+                <span className="relative z-10 flex items-center gap-3">
+                  <span className="text-xl">{user ? "📊" : "✨"}</span>
+                  {user ? "Tableau de bord" : "S'inscrire / Connexion"}
+                </span>
+                <span className="absolute inset-0 -z-0 translate-y-full bg-white/20 transition-all duration-500 group-hover:translate-y-0" />
+              </Link>
             </div>
             <div className="grid gap-4 text-sm text-slate-300/80 sm:grid-cols-2">
               <div className="rounded-3xl border border-white/10 bg-white/5 p-4 backdrop-blur">


### PR DESCRIPTION
## Summary
- expose the current user from the studio context in the landing hero
- add a CTA button that links visitors to the auth flow or dashboard depending on their session

## Testing
- npm run lint *(fails: existing parsing error in src/pages/Auth.tsx around the register form markup)*

------
https://chatgpt.com/codex/tasks/task_e_68d4df87bb408328a0a372781911a614