### PR TITLE
Refine portfolio gallery vignettes

### DIFF
--- a/src/components/WaveMenu.tsx
+++ b/src/components/WaveMenu.tsx
@@ -1,98 +1,96 @@
-import { useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { navigationItems } from "@/lib/navigation";
 import { cn } from "@/lib/utils";
 import { useStudio } from "@/context/StudioContext";
 
 export const WaveMenu = () => {
-  const [expanded, setExpanded] = useState(true);
   const location = useLocation();
-  const { visualMode, cycleVisualMode, palette } = useStudio();
+  const { visualMode, cycleVisualMode, palette, user } = useStudio();
 
   return (
     <>
-      <div className="pointer-events-none fixed right-2 top-0 z-50 hidden h-screen lg:flex">
-        <div className="pointer-events-auto flex h-full flex-col justify-center gap-4">
-          <button
-            type="button"
-            onClick={() => setExpanded((prev) => !prev)}
-            className="group relative overflow-hidden rounded-full border border-white/20 bg-slate-900/60 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white shadow-[0_0_30px_rgba(0,0,0,0.5)] backdrop-blur transition hover:bg-slate-900/80"
-          >
-            <span className="relative inline-flex items-center gap-2">
-              <span className="h-2 w-2 rounded-full bg-emerald-400 shadow-[0_0_10px_rgba(16,185,129,0.8)]" />
-              {expanded ? "Mode vague" : "Menu"}
-            </span>
-            <span className="absolute inset-0 animate-[pulse_2s_infinite] bg-gradient-to-r from-emerald-400/40 via-transparent to-cyan-500/40 opacity-0 transition group-hover:opacity-100" />
-          </button>
-          <button
-            type="button"
-            onClick={cycleVisualMode}
-            className="group relative overflow-hidden rounded-full border border-cyan-200/40 visual-accent-border bg-cyan-500/20 visual-accent-bg px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-cyan-100 visual-accent-text shadow-[0_10px_30px_rgba(8,145,178,0.25)] visual-accent-shadow transition hover:scale-105"
-          >
-            <span className="relative z-10 flex items-center gap-2">
+      <div className="pointer-events-none fixed left-1/2 top-6 z-50 flex w-full max-w-5xl -translate-x-1/2 flex-col gap-3 px-4">
+        <div className="pointer-events-auto overflow-hidden rounded-full border border-white/20 bg-slate-950/70 text-white shadow-[0_25px_60px_rgba(15,118,110,0.25)] backdrop-blur">
+          <div
+            className="pointer-events-none absolute inset-0 opacity-60"
+            style={{
+              background:
+                "linear-gradient(120deg, hsla(var(--visual-accent)/0.35), hsla(var(--visual-secondary)/0.3), hsla(var(--visual-tertiary)/0.35))",
+              backgroundSize: "200% 200%",
+              animation: "bandAurora 18s ease-in-out infinite",
+            }}
+          />
+          <div className="relative flex flex-wrap items-center gap-4 px-6 py-3">
+            <button
+              type="button"
+              onClick={cycleVisualMode}
+              className="group relative flex items-center gap-3 rounded-full border border-cyan-200/40 visual-accent-border bg-white/10 px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-cyan-100 visual-accent-text shadow-[0_10px_30px_rgba(8,145,178,0.25)] visual-accent-shadow transition hover:scale-105"
+            >
               <span
                 className="h-2.5 w-2.5 rounded-full shadow-[0_0_12px_rgba(255,255,255,0.35)]"
                 style={{ background: `hsl(${palette.accent})` }}
               />
               {visualMode === "nebula" ? "Palette Solstice" : "Palette Nébula"}
-            </span>
-            <span className="absolute inset-0 -z-10 translate-x-[-120%] bg-gradient-to-r from-cyan-400 via-sky-300 to-fuchsia-400 visual-accent-gradient transition-transform duration-700 group-hover:translate-x-0" />
-          </button>
-          <nav
-            aria-label="Menu nébuleux"
-            className={cn(
-              "relative flex w-72 origin-right flex-col gap-3 rounded-l-3xl border border-white/10 bg-gradient-to-b from-slate-950/80 via-slate-900/70 to-slate-950/80 p-4 text-sm text-white shadow-[0_0_60px_rgba(14,165,233,0.35)] transition-all duration-700",
-              expanded ? "translate-x-0 opacity-100" : "translate-x-28 opacity-0"
-            )}
-          >
-            <div className="pointer-events-none absolute -right-[60px] top-0 h-full w-[120px] overflow-hidden">
-              <div
-                className="absolute inset-0 blur-3xl"
-                style={{ background: "radial-gradient(circle at 30% 50%, hsla(var(--visual-accent)/0.7), transparent 60%)" }}
-              />
+              <span className="pointer-events-none absolute inset-0 -z-10 translate-x-[-120%] bg-gradient-to-r from-cyan-400/40 via-transparent to-fuchsia-400/40 transition-transform duration-700 group-hover:translate-x-0" />
+            </button>
+            <div className="flex min-w-0 flex-1 items-center">
+              <div className="relative flex w-full items-center gap-2 overflow-hidden">
+                <div
+                  className="pointer-events-none absolute inset-0"
+                  style={{
+                    background: "linear-gradient(90deg, transparent, rgba(255,255,255,0.15), transparent)",
+                    animation: "bandShimmer 6s linear infinite",
+                  }}
+                />
+                <div className="relative flex w-full items-center gap-2 overflow-x-auto whitespace-nowrap pb-2 pt-2">
+                  {navigationItems.map((item) => {
+                    const active = location.pathname === item.to || location.pathname.startsWith(`${item.to}/`);
+                    return (
+                      <Link
+                        key={item.to}
+                        to={item.to}
+                        className={cn(
+                          "group relative flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-xs uppercase tracking-[0.25em] transition",
+                          "hover:border-white/40 hover:bg-white/15",
+                          active
+                            ? "border-cyan-300/80 bg-white/25 text-white shadow-[0_10px_40px_rgba(56,189,248,0.35)]"
+                            : "text-slate-200/90"
+                        )}
+                      >
+                        <span className="text-lg">{item.emoji}</span>
+                        <span>{item.label}</span>
+                        <span
+                          className="pointer-events-none absolute inset-0 -z-10 translate-x-[-120%] rounded-full bg-gradient-to-r from-white/10 via-white/5 to-transparent transition-transform duration-700 group-hover:translate-x-0"
+                        />
+                      </Link>
+                    );
+                  })}
+                </div>
+              </div>
             </div>
-            {navigationItems.map((item) => {
-              const active = location.pathname === item.to || location.pathname.startsWith(`${item.to}/`);
-              return (
-                <Link
-                  key={item.to}
-                  to={item.to}
-                  className={cn(
-                    "group relative flex items-center justify-between overflow-hidden rounded-2xl border border-white/10 px-4 py-3 transition-all",
-                    "hover:border-cyan-400/80 hover:bg-white/10 hover:text-white",
-                    active ? "border-cyan-300 bg-white/20 text-white shadow-[0_0_30px_rgba(34,211,238,0.45)]" : "text-slate-200"
-                  )}
-                >
-                  <div className="flex items-center gap-3">
-                    <span className="text-xl">{item.emoji}</span>
-                    <div>
-                      <p className="text-base font-semibold uppercase tracking-[0.2em]">{item.label}</p>
-                      <p className="text-[0.7rem] text-slate-300/80">{item.tooltip}</p>
-                    </div>
-                  </div>
-                  <span className="text-xs font-mono text-cyan-300">{active ? "ON" : ".."}</span>
-                  <span
-                    className="absolute inset-0 -z-10 translate-x-[-80%] transition-transform duration-700 group-hover:translate-x-0"
-                    style={{ background: "radial-gradient(circle at right, hsla(var(--visual-accent)/0.45), transparent 60%)" }}
-                  />
-                </Link>
-              );
-            })}
-          </nav>
+            <div className="flex flex-wrap items-center gap-2">
+              <Link
+                to={user ? "/dashboard" : "/auth?mode=login"}
+                className="group relative overflow-hidden rounded-full border border-white/20 bg-white/15 px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-white transition hover:scale-105"
+              >
+                <span className="relative z-10 flex items-center gap-2">
+                  <span className="text-base">{user ? "📊" : "🔐"}</span>
+                  {user ? "Tableau de bord" : "Connexion"}
+                </span>
+                <span className="pointer-events-none absolute inset-0 -z-0 translate-y-full bg-white/20 transition-all duration-500 group-hover:translate-y-0" />
+              </Link>
+              <Link
+                to="/auth?mode=forgot"
+                className="group relative overflow-hidden rounded-full border border-white/15 bg-white/10 px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-white/90 transition hover:text-white"
+              >
+                <span className="relative z-10 flex items-center gap-2">
+                  <span className="text-base">🧠</span> Mot de passe oublié
+                </span>
+                <span className="pointer-events-none absolute inset-0 -z-0 translate-x-[-120%] bg-white/15 transition-transform duration-700 group-hover:translate-x-0" />
+              </Link>
+            </div>
+          </div>
         </div>
-      </div>
-      <div className="fixed bottom-4 right-4 z-50 pointer-events-none lg:hidden">
-        <button
-          type="button"
-          onClick={cycleVisualMode}
-          className="pointer-events-auto flex items-center gap-2 rounded-full border border-cyan-200/40 visual-accent-border bg-cyan-500/20 visual-accent-bg px-4 py-2 text-xs font-semibold uppercase tracking-[0.25em] text-cyan-100 visual-accent-text shadow-[0_10px_30px_rgba(8,145,178,0.25)] visual-accent-shadow backdrop-blur"
-        >
-          <span
-            className="h-2.5 w-2.5 rounded-full shadow-[0_0_12px_rgba(255,255,255,0.35)]"
-            style={{ background: `hsl(${palette.accent})` }}
-          />
-          {visualMode === "nebula" ? "Solstice" : "Nébula"}
-        </button>
       </div>
     </>
   );

--- a/src/context/StudioContext.tsx
+++ b/src/context/StudioContext.tsx
@@ -1,125 +1,909 @@
-/* src/pages/Process.tsx */
-const timeline = [
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from "react";
+import { v4 as uuid } from "uuid";
+import type { User } from "@supabase/supabase-js";
+
+import { getSupabaseClient, isSupabaseConfigured } from "@/lib/supabaseClient";
+
+// Local helper to generate shimmering gradient placeholders
+const gradientPool = [
+  "from-[#61f4de] via-[#2471d6] to-[#290a5c]",
+  "from-[#fd7bff] via-[#4d31ff] to-[#120248]",
+  "from-[#ffdc63] via-[#ff7a18] to-[#45108a]",
+  "from-[#5dff9d] via-[#19b6ff] to-[#5916e1]",
+  "from-[#ff9cc6] via-[#ff6c6c] to-[#2f2aa0]",
+];
+
+export type PortfolioItem = {
+  id: string;
+  title: string;
+  tagline: string;
+  category: string;
+  year: number;
+  duration: string;
+  description: string;
+  thumbnail: string;
+  videoUrl: string;
+  gradient: string;
+  aiTools: string[];
+  deliverables: string[];
+  socialStack: string[];
+};
+
+export type PricingTier = {
+  id: string;
+  name: string;
+  price: number;
+  description: string;
+  deliverables: string[];
+  sla: string;
+};
+
+export type QuoteRequest = {
+  id: string;
+  clientId: string;
+  clientName: string;
+  projectName: string;
+  budgetRange: string;
+  deadline: string;
+  services: string[];
+  status: "nouveau" | "en revue" | "validé" | "refusé";
+  moodboardPrompt: string;
+  createdAt: string;
+};
+
+export type ChatMessage = {
+  id: string;
+  from: "studio" | "client";
+  content: string;
+  timestamp: string;
+};
+
+export type ChatThread = {
+  quoteId: string;
+  clientName: string;
+  projectName: string;
+  messages: ChatMessage[];
+};
+
+export type ContactRequest = {
+  id: string;
+  name: string;
+  email: string;
+  projectSpark: string;
+  urgency: "hier" | "cette-semaine" | "quand-c-est-parfait";
+  createdAt: string;
+};
+
+export type ClientAccount = {
+  id: string;
+  name: string;
+  email: string;
+  company: string;
+  industry: string;
+  membership: "Impulse" | "Hyperdrive" | "Continuum";
+  avatarHue: number;
+  lastProject?: string;
+};
+
+type StoredClientAccount = ClientAccount & { password?: string };
+type StoredCredential = { email: string; password: string; updatedAt: string };
+
+export type RegistrationPayload = {
+  name: string;
+  email: string;
+  password: string;
+  company: string;
+  industry: string;
+  membership: ClientAccount["membership"];
+};
+
+type VisualMode = "nebula" | "solstice";
+
+type VisualPalette = {
+  accent: string;
+  accentSoft: string;
+  secondary: string;
+  tertiary: string;
+  accentForeground: string;
+  border: string;
+};
+
+const SERVICE_CATEGORIES = [
+  "Entreprise",
+  "Événementiel",
+  "Immobilier",
+  "Réseaux sociaux",
+  "Mariage",
+  "Motion design / IA",
+] as const;
+
+type StudioContextValue = {
+  user: ClientAccount | null;
+  clients: ClientAccount[];
+  portfolioItems: PortfolioItem[];
+  pricingTiers: PricingTier[];
+  quoteRequests: QuoteRequest[];
+  contactRequests: ContactRequest[];
+  chats: ChatThread[];
+  serviceCategories: typeof SERVICE_CATEGORIES;
+  visualMode: VisualMode;
+  palette: VisualPalette;
+  cycleVisualMode: () => void;
+  register: (payload: RegistrationPayload) => Promise<{ success: boolean; message?: string }>;
+  login: (email: string, password: string) => Promise<{ success: boolean; message?: string }>;
+  requestPasswordReset: (email: string) => Promise<{ success: boolean; message?: string }>;
+  logout: () => void;
+  addPortfolioItem: (payload: Omit<PortfolioItem, "id" | "gradient"> & { gradient?: string }) => void;
+  updatePortfolioItem: (id: string, updates: Partial<PortfolioItem>) => void;
+  removePortfolioItem: (id: string) => void;
+  updatePricingTier: (id: string, updates: Partial<PricingTier>) => void;
+  createQuoteRequest: (payload: Omit<QuoteRequest, "id" | "status" | "createdAt" | "clientId" | "clientName">) => QuoteRequest | null;
+  advanceQuoteStatus: (id: string, status: QuoteRequest["status"]) => void;
+  appendChatMessage: (quoteId: string, message: Omit<ChatMessage, "id" | "timestamp">) => void;
+  recordContactRequest: (payload: Omit<ContactRequest, "id" | "createdAt">) => void;
+};
+
+const StudioContext = createContext<StudioContextValue | undefined>(undefined);
+
+const visualPalettes: Record<VisualMode, VisualPalette> = {
+  nebula: {
+    accent: "188 86% 64%",
+    accentSoft: "196 90% 78%",
+    secondary: "315 86% 66%",
+    tertiary: "251 96% 72%",
+    accentForeground: "190 100% 92%",
+    border: "188 86% 64%",
+  },
+  solstice: {
+    accent: "34 97% 62%",
+    accentSoft: "17 94% 64%",
+    secondary: "296 76% 72%",
+    tertiary: "208 88% 70%",
+    accentForeground: "35 100% 92%",
+    border: "34 97% 62%",
+  },
+};
+
+const isBrowser = typeof window !== "undefined";
+
+const storageKeys = {
+  user: "studio.vbg.user",
+  clients: "studio.vbg.clients",
+  portfolio: "studio.vbg.portfolio",
+  pricing: "studio.vbg.pricing",
+  quotes: "studio.vbg.quotes",
+  contacts: "studio.vbg.contacts",
+  chats: "studio.vbg.chats",
+  visualMode: "studio.vbg.visual-mode",
+  credentials: "studio.vbg.credentials",
+} as const;
+
+const normaliseEmail = (email: string) => email.trim().toLowerCase();
+const encodePassword = (value: string) =>
+  Array.from(value)
+    .map((char) => char.charCodeAt(0).toString(16).padStart(2, "0"))
+    .join("");
+
+const readStorage = <T,>(key: string, fallback: T): T => {
+  if (!isBrowser) return fallback;
+  try {
+    const stored = window.localStorage.getItem(key);
+    if (!stored) return fallback;
+    return JSON.parse(stored) as T;
+  } catch (error) {
+    console.error(`Impossible de lire le stockage local pour ${key}`, error);
+    return fallback;
+  }
+};
+
+const writeStorage = (key: string, value: unknown) => {
+  if (!isBrowser) return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    console.error(`Impossible d'écrire dans le stockage local pour ${key}`, error);
+  }
+};
+
+const removeStorage = (key: string) => {
+  if (!isBrowser) return;
+  window.localStorage.removeItem(key);
+};
+
+const initialPortfolio: PortfolioItem[] = [
   {
-    id: "brief",
-    title: "Brief initial",
+    id: uuid(),
+    title: "Pulse HoloBoard · Lancement corporate QuantumLoop",
+    tagline: "Accompagnement de 12 000 collaborateurs avec un dispositif immersif",
+    category: SERVICE_CATEGORIES[0],
+    year: 2025,
+    duration: "01:32",
     description:
-      "Nous analysons votre contexte, vos objectifs et vos audiences. Notre IA priorise les informations clés et structure les premières pistes créatives.",
-    gradient:
-      "radial-gradient(circle at top, hsla(var(--visual-accent)/0.25), transparent 70%)",
+      "Film d'entreprise réalisé sur plateau robotisé avec incrustations temps réel Kling 2.5. Script co-écrit avec notre IA rédactionnelle pour rendre accessible la transformation digitale et déclinaisons dédiées aux équipes internes.",
+    thumbnail: "https://images.unsplash.com/photo-1522199992901-41860af3a7f3?q=80&w=1200",
+    videoUrl: "https://www.youtube.com/watch?v=s6zR2T9vn2c",
+    gradient: gradientPool[0],
+    aiTools: ["Midjourney V7", "Kling 2.5", "DaVinci Resolve"],
+    deliverables: ["Film principal 16:9", "Version onboarding 9:16", "Kit de présentation interne"],
+    socialStack: ["Intranet", "LinkedIn", "YouTube"],
   },
   {
-    id: "design",
-    title: "Conception narrative",
+    id: uuid(),
+    title: "Aftermovie NeoSolar · Festival IA & lumière",
+    tagline: "Aftermovie immersif pour un festival dédié à l'innovation lumineuse",
+    category: SERVICE_CATEGORIES[1],
+    year: 2024,
+    duration: "02:08",
     description:
-      "Moodboards Midjourney V7, scripts générés et découpage technique. Chaque séquence est associée à un objectif précis et à des indicateurs de performance.",
-    gradient:
-      "radial-gradient(circle at 60% 20%, hsla(var(--visual-secondary)/0.28), transparent 70%)",
+      "Captation événementielle associant drones FPV, Seedance Pro pour anticiper les mouvements de foule et montage synchronisé Suno AI. Objectif : donner envie de s'inscrire dès l'ouverture de la prochaine édition.",
+    thumbnail: "https://images.unsplash.com/photo-1514525253161-7a46d19cd819?q=80&w=1200",
+    videoUrl: "https://www.youtube.com/watch?v=aqz-KE-bpKQ",
+    gradient: gradientPool[1],
+    aiTools: ["Seedance Pro", "Suno AI", "DaVinci Resolve"],
+    deliverables: ["Aftermovie 4K", "Teaser 30s", "Stories pré-event"],
+    socialStack: ["Instagram", "TikTok", "YouTube Shorts"],
   },
   {
-    id: "shoot",
-    title: "Production",
+    id: uuid(),
+    title: "Skyline Loop · Visite immobilière narrée par IA",
+    tagline: "Visite premium d'un penthouse avec narration IA",
+    category: SERVICE_CATEGORIES[2],
+    year: 2025,
+    duration: "01:05",
     description:
-      "Seedance Pro anticipe les mouvements caméra, Kling 2.5 projette les décors et nos équipes plateau pilotent chaque séquence avec précision.",
-    gradient:
-      "radial-gradient(circle at 30% 80%, hsla(var(--visual-tertiary)/0.24), transparent 70%)",
+      "Visite immersive en drone FPV avec overlays data générés par Kling 2.5 et voix off Suno IA. Chaque pièce est présentée comme un chapitre et l'appel à l'action est piloté via QR code interactif.",
+    thumbnail: "https://images.unsplash.com/photo-1487956382158-bb926046304a?q=80&w=1200",
+    videoUrl: "https://www.youtube.com/watch?v=0pdqf4P9MB8",
+    gradient: gradientPool[2],
+    aiTools: ["Midjourney V7", "Kling 2.5", "Suno AI"],
+    deliverables: ["Film 16:9", "Version VR", "Carousel LinkedIn"],
+    socialStack: ["YouTube", "Website", "Meta Ads"],
   },
   {
-    id: "post",
-    title: "Postproduction",
+    id: uuid(),
+    title: "Snackverse · Série sociale pour WaveBite",
+    tagline: "Série verticale de 12 épisodes conçue pour la conversion",
+    category: SERVICE_CATEGORIES[3],
+    year: 2025,
+    duration: "00:45",
     description:
-      "Veo 3 accélère le montage, Davinci assure la colorimétrie, Suno AI compose le sound design et LypSync V2 harmonise les voix.",
-    gradient:
-      "radial-gradient(circle at bottom right, hsla(var(--visual-accent-soft)/0.24), transparent 70%)",
+      "Production sociale verticale pilotée par IA : scripts testés via GPT CopyLab, tournage en LED volume, montage automatisé Veo 3 et templates livrés aux équipes internes.",
+    thumbnail: "https://images.unsplash.com/photo-1521737604893-d14cc237f11d?q=80&w=1200",
+    videoUrl: "https://www.youtube.com/watch?v=jNQXAC9IVRw",
+    gradient: gradientPool[3],
+    aiTools: ["Veo 3", "Midjourney V7", "Adobe Premiere Pro"],
+    deliverables: ["Série 12x45s", "Capsules additionnelles", "Scripts automatisés"],
+    socialStack: ["TikTok", "Snap", "YouTube Shorts"],
   },
   {
-    id: "launch",
-    title: "Diffusion",
+    id: uuid(),
+    title: "Orbit Lovers · Mariage futuriste en live",
+    tagline: "Cérémonie captée en direct avec diffusion privée",
+    category: SERVICE_CATEGORIES[4],
+    year: 2024,
+    duration: "03:20",
     description:
-      "Nous publions, suivons la performance et ajustons les formats. Les reportings sont partagés en temps réel via le tableau de bord.",
-    gradient:
-      "radial-gradient(circle at 50% 50%, hsla(var(--visual-secondary)/0.22), transparent 70%)",
+      "Captation mariage premium : drones, steadycam, robot caméra et IA pour générer les vœux animés. Diffusion live privée et montage highlight livré avant la fin de la réception.",
+    thumbnail: "https://images.unsplash.com/photo-1520854221050-0f4caff449fb?q=80&w=1200",
+    videoUrl: "https://www.youtube.com/watch?v=oUFJJNQGwhk",
+    gradient: gradientPool[4],
+    aiTools: ["Seedance Pro", "DaVinci Resolve", "Suno AI"],
+    deliverables: ["Live multi-cam", "Highlight 3min", "Stories pour les invités"],
+    socialStack: ["YouTube privé", "Instagram", "Galerie partagée"],
+  },
+  {
+    id: uuid(),
+    title: "LogoVerse · Identité motion générée",
+    tagline: "Création d'identité motion design propulsée par l'IA",
+    category: SERVICE_CATEGORIES[5],
+    year: 2025,
+    duration: "00:36",
+    description:
+      "Création de logo animé via Midjourney V7 puis animatic Kling 2.5. Sound design Suno AI et packaging template pour diffusion OTT et dispositifs immersifs.",
+    thumbnail: "https://images.unsplash.com/photo-1545239351-1141bd82e8a6?q=80&w=1200",
+    videoUrl: "https://www.youtube.com/watch?v=ysz5S6PUM-U",
+    gradient: gradientPool[0],
+    aiTools: ["Midjourney V7", "Kling 2.5", "After Effects"],
+    deliverables: ["Logo animé 4 formats", "Banque transitions", "Kit son identité"],
+    socialStack: ["Behance", "Vimeo", "TikTok"],
   },
 ];
 
-const Process = () => {
-  return (
-    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-white">
-      <div
-        className="pointer-events-none absolute inset-0"
-        style={{
-          background:
-            "conic-gradient(from 60deg at 50% 50%, hsla(var(--visual-accent)/0.22), transparent 70%)",
-        }}
-      />
+const initialPricing: PricingTier[] = [
+  {
+    id: uuid(),
+    name: "Impulse",
+    price: 4200,
+    description: "Idéal pour un lancement ou un événement clé avec délais courts",
+    deliverables: ["Sprint créatif IA", "Tournage studio 4h", "Kit social 6 formats"],
+    sla: "Livraison 4K sous 72 heures",
+  },
+  {
+    id: uuid(),
+    name: "Hyperdrive",
+    price: 9700,
+    description: "Campagne multi-canal pilotée par notre pipeline intelligent",
+    deliverables: ["Storyboard Midjourney V7", "Tournage bi-cam", "Montage Davinci + VFX Veo 3"],
+    sla: "Pilotage complet sur 21 jours",
+  },
+  {
+    id: uuid(),
+    name: "Continuum",
+    price: 18200,
+    description: "Programme annuel incluant production continue, live et data storytelling",
+    deliverables: ["Retainer production mensuelle", "Lives trimestriels Seedance", "Veille tendances et optimisation"],
+    sla: "Équipe dédiée et dashboard 24/7",
+  },
+];
 
-      <div className="relative mx-auto max-w-6xl px-6 pb-32 pt-28">
-        <header className="rounded-[3rem] border border-white/10 bg-white/5 p-12 shadow-[0_20px_120px_rgba(14,165,233,0.2)] visual-accent-veil">
-          <div className="space-y-6">
-            <span className="inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.35em] text-cyan-100/80 visual-accent-text-strong">
-              Processus Studio VBG
-            </span>
-            <h1 className="text-5xl font-black leading-tight">
-              Notre méthodologie de production vidéo
-            </h1>
-            <p className="text-lg text-slate-200/80">
-              De la définition du brief à la diffusion, chaque étape est
-              orchestrée pour garantir une qualité constante et une visibilité
-              complète sur l'avancement.
-            </p>
-          </div>
-        </header>
+const initialClients: ClientAccount[] = [
+  {
+    id: uuid(),
+    name: "Thomas Volberg",
+    email: "volberg.thomas@gmail.com",
+    company: "Studio VBG",
+    industry: "Production vidéo",
+    membership: "Continuum",
+    avatarHue: 24,
+    lastProject: "Pulse HoloBoard",
+  },
+  {
+    id: uuid(),
+    name: "Lena Photon",
+    email: "lena@quantumwear.ai",
+    company: "QuantumWear",
+    industry: "Tech santé",
+    membership: "Hyperdrive",
+    avatarHue: 182,
+    lastProject: "Sillage Quantique",
+  },
+];
 
-        <section className="mt-16 space-y-12">
-          {timeline.map((step, index) => (
-            <article
-              key={step.id}
-              className="relative overflow-hidden rounded-[3rem] border border-white/10 bg-white/5 p-10 shadow-[0_20px_110px_rgba(56,189,248,0.15)] visual-accent-veil"
-              style={{ backgroundImage: step.gradient }}
-            >
-              <span className="absolute left-12 top-8 text-6xl font-black text-white/10">
-                0{index + 1}
-              </span>
-              <div className="relative grid gap-6 lg:grid-cols-[1.2fr_1fr]">
-                <div className="space-y-4">
-                  <h2 className="text-3xl font-extrabold">{step.title}</h2>
-                  <p className="text-lg text-slate-200/80">{step.description}</p>
-                </div>
+const initialCredentials: StoredCredential[] = [
+  {
+    email: normaliseEmail("volberg.thomas@gmail.com"),
+    password: encodePassword("StudioVBG2025!"),
+    updatedAt: new Date().toISOString(),
+  },
+  {
+    email: normaliseEmail("lena@quantumwear.ai"),
+    password: encodePassword("Hyperdrive2025!"),
+    updatedAt: new Date().toISOString(),
+  },
+];
 
-                <div className="rounded-[2.5rem] border border-white/10 bg-white/10 p-6 text-sm text-slate-200/70">
-                  <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">
-                    Livrables associés
-                  </p>
-                  <p className="mt-3">
-                    {index === 0 &&
-                      "Compte rendu synthétique, plan d'action initial et échéancier partagé."}
-                    {index === 1 &&
-                      "Scénario validé, moodboards, prévisualisations et planning de tournage."}
-                    {index === 2 &&
-                      "Feuilles de service, captations sécurisées, rushes organisés et backups."}
-                    {index === 3 &&
-                      "Montages intermédiaires, validations collaboratives et exports multi-plateformes."}
-                    {index === 4 &&
-                      "Calendrier de diffusion, reporting de performance et recommandations d'optimisation."}
-                  </p>
-                </div>
-              </div>
-            </article>
-          ))}
-        </section>
-
-        <section className="mt-16 rounded-[3rem] border border-white/10 bg-white/5 p-12 text-center text-sm text-slate-200/70">
-          <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">
-            Prêt à collaborer ?
-          </p>
-          <p className="mt-6 text-3xl font-semibold text-white">
-            Connectez-vous, partagez votre brief et nous lançons la production
-            dans les meilleurs délais.
-          </p>
-        </section>
-      </div>
-    </div>
-  );
+const ensureAdminClient = (list: ClientAccount[]): ClientAccount[] => {
+  const adminEmail = initialClients[0].email;
+  const hasAdmin = list.some((client) => client.email === adminEmail);
+  return hasAdmin ? list : [initialClients[0], ...list];
 };
 
-export default Process;
+const loadInitialClients = () => {
+  const stored = readStorage<StoredClientAccount[]>(storageKeys.clients, initialClients);
+  const sanitized = stored.map(({ password: _password, ...client }) => ({
+    ...client,
+    avatarHue: typeof client.avatarHue === "number" ? client.avatarHue : Math.floor(Math.random() * 360),
+  }));
+  return ensureAdminClient(sanitized);
+};
+const loadInitialPortfolio = () => readStorage<PortfolioItem[]>(storageKeys.portfolio, initialPortfolio);
+const loadInitialPricing = () => readStorage<PricingTier[]>(storageKeys.pricing, initialPricing);
+const loadInitialQuotes = () => readStorage<QuoteRequest[]>(storageKeys.quotes, initialQuotes);
+const loadInitialContacts = () => readStorage<ContactRequest[]>(storageKeys.contacts, []);
+const loadInitialChats = () => readStorage<ChatThread[]>(storageKeys.chats, initialChats);
+const loadInitialVisualMode = () => readStorage<VisualMode>(storageKeys.visualMode, "nebula");
+const loadInitialUser = () => {
+  const storedUser = readStorage<(ClientAccount & { password?: string }) | null>(storageKeys.user, null);
+  if (!storedUser) return null;
+  const { password: _password, ...safeUser } = storedUser;
+  const candidates = loadInitialClients();
+  return candidates.find((client) => client.email === safeUser.email) ?? safeUser;
+};
+const loadInitialCredentials = () =>
+  readStorage<StoredCredential[]>(storageKeys.credentials, initialCredentials);
+
+const initialQuotes: QuoteRequest[] = [
+  {
+    id: uuid(),
+    clientId: initialClients[1].id,
+    clientName: initialClients[1].name,
+    projectName: "Activation wearable SXSW",
+    budgetRange: "12k€ - 18k€",
+    deadline: "2025-03-11",
+    services: ["Captation multicam", "Scénarisation assistée par IA", "Pack réseaux sociaux"],
+    status: "en revue",
+    moodboardPrompt:
+      "Imagine a slow-motion capture of biometric data turning into aurora borealis patterns inside a dome stage.",
+    createdAt: new Date().toISOString(),
+  },
+];
+
+const initialChats: ChatThread[] = [
+  {
+    quoteId: initialQuotes[0].id,
+    clientName: initialClients[1].name,
+    projectName: initialQuotes[0].projectName,
+    messages: [
+      {
+        id: uuid(),
+        from: "client",
+        content: "On peut ajouter une version 9:16 verticale ?",
+        timestamp: new Date().toISOString(),
+      },
+      {
+        id: uuid(),
+        from: "studio",
+        content: "Bien sûr, on la génère via Veo 3 + montage Davinci. Je t'envoie le chiffrage dans 5 minutes.",
+        timestamp: new Date().toISOString(),
+      },
+    ],
+  },
+];
+
+const StudioProvider = ({ children }: { children: ReactNode }) => {
+  const supabase = getSupabaseClient();
+  const [user, setUser] = useState<ClientAccount | null>(loadInitialUser);
+  const [clients, setClients] = useState<ClientAccount[]>(loadInitialClients);
+  const [credentials, setCredentials] = useState<StoredCredential[]>(loadInitialCredentials);
+  const [portfolioItems, setPortfolioItems] = useState<PortfolioItem[]>(loadInitialPortfolio);
+  const [pricingTiers, setPricingTiers] = useState<PricingTier[]>(loadInitialPricing);
+  const [quoteRequests, setQuoteRequests] = useState<QuoteRequest[]>(loadInitialQuotes);
+  const [contactRequests, setContactRequests] = useState<ContactRequest[]>(loadInitialContacts);
+  const [chats, setChats] = useState<ChatThread[]>(loadInitialChats);
+  const [visualMode, setVisualMode] = useState<VisualMode>(loadInitialVisualMode);
+
+  const syncClientFromSupabase = useCallback(
+    (supabaseUser: User): ClientAccount => {
+      const metadata = (supabaseUser.user_metadata ?? {}) as Partial<
+        RegistrationPayload & { avatarHue?: number; lastProject?: string }
+      >;
+
+      const nextClient: ClientAccount = {
+        id: supabaseUser.id,
+        name: metadata.name ?? supabaseUser.email ?? "Compte Studio VBG",
+        email: supabaseUser.email ?? "",
+        company: metadata.company ?? "",
+        industry: metadata.industry ?? "",
+        membership: (metadata.membership as ClientAccount["membership"]) ?? "Hyperdrive",
+        avatarHue:
+          typeof metadata.avatarHue === "number"
+            ? metadata.avatarHue
+            : Math.floor(Math.random() * 360),
+        lastProject: metadata.lastProject,
+      };
+
+      setClients((prev) => {
+        const exists = prev.some((client) => client.email === nextClient.email);
+        const updated = exists
+          ? prev.map((client) => (client.email === nextClient.email ? { ...client, ...nextClient } : client))
+          : [...prev, nextClient];
+        return ensureAdminClient(updated);
+      });
+
+      return nextClient;
+    },
+    [setClients],
+  );
+
+  useEffect(() => {
+    if (!supabase) {
+      return;
+    }
+
+    let isMounted = true;
+
+    supabase.auth
+      .getSession()
+      .then(({ data }) => {
+        if (!isMounted) return;
+        const sessionUser = data.session?.user;
+        if (sessionUser) {
+          const nextClient = syncClientFromSupabase(sessionUser);
+          setUser(nextClient);
+        }
+      })
+      .catch((error) => {
+        console.error("Impossible de récupérer la session Supabase", error);
+      });
+
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (!isMounted) return;
+      const sessionUser = session?.user;
+      if (sessionUser) {
+        const nextClient = syncClientFromSupabase(sessionUser);
+        setUser(nextClient);
+      } else {
+        setUser(null);
+      }
+    });
+
+    return () => {
+      isMounted = false;
+      listener.subscription.unsubscribe();
+    };
+  }, [supabase, syncClientFromSupabase]);
+
+  useEffect(() => {
+    const body = document.body;
+    body.classList.remove("visual-nebula", "visual-solstice");
+    body.classList.add(`visual-${visualMode}`);
+
+    const palette = visualPalettes[visualMode];
+    const root = document.documentElement;
+    root.style.setProperty("--visual-accent", palette.accent);
+    root.style.setProperty("--visual-accent-soft", palette.accentSoft);
+    root.style.setProperty("--visual-secondary", palette.secondary);
+    root.style.setProperty("--visual-tertiary", palette.tertiary);
+    root.style.setProperty("--visual-accent-foreground", palette.accentForeground);
+    root.style.setProperty("--visual-border", palette.border);
+
+    writeStorage(storageKeys.visualMode, visualMode);
+  }, [visualMode]);
+
+  useEffect(() => {
+    writeStorage(storageKeys.clients, clients);
+  }, [clients]);
+
+  useEffect(() => {
+    writeStorage(storageKeys.credentials, credentials);
+  }, [credentials]);
+
+  useEffect(() => {
+    if (user) {
+      writeStorage(storageKeys.user, user);
+    } else {
+      removeStorage(storageKeys.user);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    writeStorage(storageKeys.portfolio, portfolioItems);
+  }, [portfolioItems]);
+
+  useEffect(() => {
+    writeStorage(storageKeys.pricing, pricingTiers);
+  }, [pricingTiers]);
+
+  useEffect(() => {
+    writeStorage(storageKeys.quotes, quoteRequests);
+  }, [quoteRequests]);
+
+  useEffect(() => {
+    writeStorage(storageKeys.contacts, contactRequests);
+  }, [contactRequests]);
+
+  useEffect(() => {
+    writeStorage(storageKeys.chats, chats);
+  }, [chats]);
+
+  const cycleVisualMode = () => {
+    setVisualMode((current) => (current === "nebula" ? "solstice" : "nebula"));
+  };
+
+  const register: StudioContextValue["register"] = async (payload) => {
+    const { password, ...profile } = payload;
+    const avatarHue = Math.floor(Math.random() * 360);
+    const normalizedEmail = normaliseEmail(profile.email);
+
+    if (!supabase || !isSupabaseConfigured) {
+      if (credentials.some((credential) => credential.email === normalizedEmail)) {
+        return {
+          success: false,
+          message: "Un compte existe déjà avec cette adresse email. Essayez de vous connecter.",
+        };
+      }
+
+      const newClient: ClientAccount = {
+        id: uuid(),
+        name: profile.name,
+        email: profile.email.trim(),
+        company: profile.company,
+        industry: profile.industry,
+        membership: profile.membership,
+        avatarHue,
+        lastProject: "Premier projet à venir",
+      };
+
+      setClients((prev) => ensureAdminClient([...prev, newClient]));
+      setCredentials((prev) => [
+        ...prev,
+        {
+          email: normalizedEmail,
+          password: encodePassword(password),
+          updatedAt: new Date().toISOString(),
+        },
+      ]);
+      setUser(newClient);
+
+      return {
+        success: true,
+        message:
+          "Compte créé en mode démo. Vous êtes connecté·e et pouvez accéder immédiatement au tableau de bord.",
+      };
+    }
+
+    try {
+      const { data, error } = await supabase.auth.signUp({
+        email: profile.email,
+        password,
+        options: {
+          data: {
+            ...profile,
+            avatarHue,
+          },
+          emailRedirectTo: typeof window !== "undefined" ? `${window.location.origin}/auth` : undefined,
+        },
+      });
+
+      if (error) {
+        return { success: false, message: error.message };
+      }
+
+      if (data.user) {
+        const syncedClient = syncClientFromSupabase(data.user);
+        if (data.session) {
+          setUser(syncedClient);
+        }
+      }
+
+      if (!data.session) {
+        return {
+          success: true,
+          message: "Compte créé. Confirmez votre adresse email pour accéder au tableau de bord.",
+        };
+      }
+
+      return { success: true };
+    } catch (error) {
+      console.error("Erreur d'inscription Supabase", error);
+      return {
+        success: false,
+        message: "Une erreur inattendue est survenue lors de l'inscription.",
+      };
+    }
+  };
+
+  const login: StudioContextValue["login"] = async (email, password) => {
+    if (!supabase || !isSupabaseConfigured) {
+      const normalizedEmail = normaliseEmail(email);
+      const storedCredential = credentials.find((credential) => credential.email === normalizedEmail);
+
+      if (!storedCredential) {
+        return {
+          success: false,
+          message: "Aucun compte n'est associé à cette adresse. Créez votre espace client.",
+        };
+      }
+
+      if (storedCredential.password !== encodePassword(password)) {
+        return { success: false, message: "Mot de passe incorrect." };
+      }
+
+      const matchingClient = clients.find((client) => normaliseEmail(client.email) === normalizedEmail);
+
+      if (!matchingClient) {
+        return {
+          success: false,
+          message: "Impossible de retrouver votre profil client. Réalisez une nouvelle inscription.",
+        };
+      }
+
+      setUser(matchingClient);
+      return { success: true, message: "Connexion réussie." };
+    }
+
+    try {
+      const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+      if (error) {
+        return { success: false, message: error.message };
+      }
+
+      if (data.user) {
+        const syncedClient = syncClientFromSupabase(data.user);
+        setUser(syncedClient);
+      }
+
+      return { success: true };
+    } catch (error) {
+      console.error("Erreur de connexion Supabase", error);
+      return {
+        success: false,
+        message: "Impossible de se connecter pour le moment.",
+      };
+    }
+  };
+
+  const requestPasswordReset: StudioContextValue["requestPasswordReset"] = async (email) => {
+    if (!supabase || !isSupabaseConfigured) {
+      const normalizedEmail = normaliseEmail(email);
+      const storedCredential = credentials.find((credential) => credential.email === normalizedEmail);
+
+      if (!storedCredential) {
+        return {
+          success: false,
+          message: "Adresse inconnue. Vérifiez l'orthographe ou créez un nouveau compte.",
+        };
+      }
+
+      return {
+        success: true,
+        message:
+          "Mode démo : contactez support@studiovbg.fr pour réinitialiser votre mot de passe, ou inscrivez-vous de nouveau.",
+      };
+    }
+
+    try {
+      const { error } = await supabase.auth.resetPasswordForEmail(email, {
+        redirectTo: typeof window !== "undefined" ? `${window.location.origin}/auth` : undefined,
+      });
+
+      if (error) {
+        return { success: false, message: error.message };
+      }
+
+      return {
+        success: true,
+        message: "Un email de réinitialisation vient d'être envoyé. Consultez votre boîte de réception.",
+      };
+    } catch (error) {
+      console.error("Erreur de réinitialisation du mot de passe Supabase", error);
+      return {
+        success: false,
+        message: "Impossible d'envoyer le lien de réinitialisation pour le moment.",
+      };
+    }
+  };
+
+  const logout = () => {
+    if (supabase) {
+      supabase.auth.signOut().catch((error) => {
+        console.error("Erreur lors de la déconnexion Supabase", error);
+      });
+    }
+    setUser(null);
+  };
+
+  const addPortfolioItem: StudioContextValue["addPortfolioItem"] = ({ gradient, ...payload }) => {
+    const newItem: PortfolioItem = {
+      ...payload,
+      id: uuid(),
+      gradient: gradient ?? gradientPool[Math.floor(Math.random() * gradientPool.length)],
+    };
+
+    setPortfolioItems((prev) => [newItem, ...prev]);
+  };
+
+  const updatePortfolioItem: StudioContextValue["updatePortfolioItem"] = (id, updates) => {
+    setPortfolioItems((prev) => prev.map((item) => (item.id === id ? { ...item, ...updates } : item)));
+  };
+
+  const removePortfolioItem: StudioContextValue["removePortfolioItem"] = (id) => {
+    setPortfolioItems((prev) => prev.filter((item) => item.id !== id));
+  };
+
+  const updatePricingTier: StudioContextValue["updatePricingTier"] = (id, updates) => {
+    setPricingTiers((prev) => prev.map((tier) => (tier.id === id ? { ...tier, ...updates } : tier)));
+  };
+
+  const createQuoteRequest: StudioContextValue["createQuoteRequest"] = (payload) => {
+    if (!user) return null;
+
+    const newQuote: QuoteRequest = {
+      ...payload,
+      id: uuid(),
+      clientId: user.id,
+      clientName: user.name,
+      status: "nouveau",
+      createdAt: new Date().toISOString(),
+    };
+
+    setQuoteRequests((prev) => [newQuote, ...prev]);
+    return newQuote;
+  };
+
+  const ensureChatThread = (quoteId: string, clientName: string, projectName: string) => {
+    setChats((prev) => {
+      const exists = prev.some((thread) => thread.quoteId === quoteId);
+      if (exists) return prev;
+      return [
+        ...prev,
+        {
+          quoteId,
+          clientName,
+          projectName,
+          messages: [
+            {
+              id: uuid(),
+              from: "studio",
+              content: "Bonjour, nous ouvrons ce canal pour préciser votre projet.",
+              timestamp: new Date().toISOString(),
+            },
+          ],
+        },
+      ];
+    });
+  };
+
+  const advanceQuoteStatus: StudioContextValue["advanceQuoteStatus"] = (id, status) => {
+    setQuoteRequests((prev) =>
+      prev.map((quote) => {
+        if (quote.id === id) {
+          if (status === "validé") {
+            ensureChatThread(quote.id, quote.clientName, quote.projectName);
+          }
+          return { ...quote, status };
+        }
+        return quote;
+      }),
+    );
+  };
+
+  const appendChatMessage: StudioContextValue["appendChatMessage"] = (quoteId, message) => {
+    setChats((prev) =>
+      prev.map((thread) =>
+        thread.quoteId === quoteId
+          ? {
+              ...thread,
+              messages: [
+                ...thread.messages,
+                {
+                  ...message,
+                  id: uuid(),
+                  timestamp: new Date().toISOString(),
+                },
+              ],
+            }
+          : thread,
+      ),
+    );
+  };
+
+  const recordContactRequest: StudioContextValue["recordContactRequest"] = (payload) => {
+    const newRequest: ContactRequest = {
+      ...payload,
+      id: uuid(),
+      createdAt: new Date().toISOString(),
+    };
+
+    setContactRequests((prev) => [newRequest, ...prev]);
+  };
+
+  const value: StudioContextValue = {
+    user,
+    clients,
+    portfolioItems,
+    pricingTiers,
+    quoteRequests,
+    contactRequests,
+    chats,
+    serviceCategories: SERVICE_CATEGORIES,
+    visualMode,
+    palette: visualPalettes[visualMode],
+    cycleVisualMode,
+    register,
+    login,
+    requestPasswordReset,
+    logout,
+    addPortfolioItem,
+    updatePortfolioItem,
+    removePortfolioItem,
+    updatePricingTier,
+    createQuoteRequest,
+    advanceQuoteStatus,
+    appendChatMessage,
+    recordContactRequest,
+  };
+
+  return <StudioContext.Provider value={value}>{children}</StudioContext.Provider>;
+};
+
+const useStudio = () => {
+  const context = useContext(StudioContext);
+  if (!context) {
+    throw new Error("useStudio doit être utilisé dans un StudioProvider");
+  }
+  return context;
+};
+
+export { StudioProvider, useStudio, SERVICE_CATEGORIES };

--- a/src/index.css
+++ b/src/index.css
@@ -257,6 +257,36 @@ All colors MUST be HSL.
   }
 }
 
+@keyframes bandAurora {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
+@keyframes bandShimmer {
+  0% {
+    transform: translateX(-130%) skewX(-12deg);
+    opacity: 0;
+  }
+  35% {
+    opacity: 0.45;
+  }
+  60% {
+    transform: translateX(20%) skewX(-12deg);
+    opacity: 0.6;
+  }
+  100% {
+    transform: translateX(130%) skewX(-12deg);
+    opacity: 0;
+  }
+}
+
 @layer utilities {
   .portfolio-aurora-cloud {
     position: absolute;
@@ -384,14 +414,13 @@ All colors MUST be HSL.
 
   .portfolio-card {
     position: relative;
-    display: flex;
-    flex-direction: column;
+    display: block;
     overflow: hidden;
-    border-radius: 3rem;
+    border-radius: 1.75rem;
     border: 1px solid hsla(var(--visual-border) / 0.25);
-    background: linear-gradient(150deg, hsla(var(--visual-accent) / 0.12), hsla(var(--visual-secondary) / 0.12) 45%, hsla(var(--visual-tertiary) / 0.15));
-    box-shadow: 0 35px 120px hsla(var(--visual-accent) / 0.2);
-    transition: transform 0.8s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.8s cubic-bezier(0.22, 1, 0.36, 1);
+    background: linear-gradient(150deg, hsla(var(--visual-accent) / 0.16), hsla(var(--visual-secondary) / 0.14) 45%, hsla(var(--visual-tertiary) / 0.18));
+    box-shadow: 0 28px 90px hsla(var(--visual-accent) / 0.22);
+    transition: transform 0.6s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.6s cubic-bezier(0.22, 1, 0.36, 1);
     will-change: transform;
     cursor: pointer;
     isolation: isolate;
@@ -423,8 +452,8 @@ All colors MUST be HSL.
   }
 
   .portfolio-card:hover {
-    transform: translateY(-12px) scale(1.015) rotate(-0.4deg);
-    box-shadow: 0 55px 160px hsla(var(--visual-accent) / 0.32);
+    transform: translateY(-6px) scale(1.01);
+    box-shadow: 0 45px 140px hsla(var(--visual-accent) / 0.32);
   }
 
   .portfolio-card:hover::before {
@@ -438,7 +467,7 @@ All colors MUST be HSL.
 
   .portfolio-card-media {
     position: relative;
-    aspect-ratio: 4 / 5;
+    aspect-ratio: 16 / 9;
     overflow: hidden;
   }
 
@@ -449,21 +478,26 @@ All colors MUST be HSL.
     transition: opacity 0.6s ease;
   }
 
-  .portfolio-card-copy {
+  .portfolio-card-top {
     position: absolute;
-    left: 1.75rem;
-    right: 1.75rem;
-    bottom: 1.75rem;
-    display: grid;
-    gap: 0.45rem;
+    top: 1.25rem;
+    left: 1.5rem;
+    right: 1.5rem;
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.65rem;
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
+    color: hsla(0 0% 100% / 0.75);
   }
 
-  .portfolio-card-meta {
-    padding: 1.75rem;
-    padding-bottom: 2rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
+  .portfolio-card-copy {
+    position: absolute;
+    left: 1.5rem;
+    right: 1.5rem;
+    bottom: 1.5rem;
+    display: grid;
+    gap: 0.45rem;
   }
 
   .portfolio-card-cta {
@@ -472,7 +506,7 @@ All colors MUST be HSL.
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 0.7rem;
+    font-size: 0.65rem;
     letter-spacing: 0.35em;
     text-transform: uppercase;
     background: hsla(229 84% 5% / 0.72);
@@ -483,7 +517,7 @@ All colors MUST be HSL.
   }
 
   .portfolio-card:hover .portfolio-card-overlay {
-    opacity: 0.92;
+    opacity: 0.95;
   }
 
   .portfolio-card:hover .portfolio-card-cta {

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -5,17 +5,22 @@ const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 export const isSupabaseConfigured = Boolean(supabaseUrl && supabaseAnonKey);
 
-let supabase: SupabaseClient | undefined;
+let supabase: SupabaseClient | null = null;
 
 const isBrowser = typeof window !== "undefined";
 
 export const getSupabaseClient = () => {
   if (!supabase) {
-    if (!supabaseUrl || !supabaseAnonKey) {
-      console.warn("Supabase credentials are missing. Provide VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY.");
+    if (!isSupabaseConfigured) {
+      if (import.meta.env.DEV) {
+        console.warn(
+          "Supabase credentials are missing. Provide VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY to enable authentication.",
+        );
+      }
+      return null;
     }
 
-    supabase = createClient(supabaseUrl ?? "", supabaseAnonKey ?? "", {
+    supabase = createClient(supabaseUrl!, supabaseAnonKey!, {
       auth: {
         persistSession: true,
         autoRefreshToken: true,

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -1,16 +1,74 @@
-import { FormEvent, useEffect, useState } from "react";
+import { FormEvent, useEffect, useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
+
 import { useStudio } from "@/context/StudioContext";
+import { cn } from "@/lib/utils";
+
+const membershipTiers = [
+  {
+    value: "Hyperdrive",
+    label: "Hyperdrive",
+    tagline: "Production intensive",
+    description:
+      "3 tournages prioritaires par mois, cellule IA dédiée et reportings hebdomadaires.",
+  },
+  {
+    value: "Cinematic",
+    label: "Cinematic",
+    tagline: "Pack signature",
+    description:
+      "Mix plateau / IA, direction artistique senior, livraison multi-formats en 7 jours.",
+  },
+  {
+    value: "Launchpad",
+    label: "Launchpad",
+    tagline: "Accélérateur",
+    description:
+      "Kit contenu mensuel, optimisation réseaux sociaux et accompagnement éditorial.",
+  },
+] as const;
+
+type MembershipPlan = (typeof membershipTiers)[number]["value"];
+type AuthMode = "register" | "login" | "forgot";
 
 const Auth = () => {
-  const [mode, setMode] = useState<"login" | "register">("register");
+  const [mode, setMode] = useState<AuthMode>("register");
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const { register: registerUser, login, user } = useStudio();
+  const { register: registerUser, login, requestPasswordReset, user } = useStudio();
   const navigate = useNavigate();
   const location = useLocation();
   const redirectPath = (location.state as { from?: string })?.from ?? "/dashboard";
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const view = params.get("mode");
+
+    if (view === "login" || view === "register" || view === "forgot") {
+      setMode(view);
+    } else {
+      setMode("register");
+    }
+
+    setError(null);
+    setSuccess(null);
+  }, [location.search]);
+
+  const changeMode = (nextMode: AuthMode) => {
+    setMode(nextMode);
+    setError(null);
+    setSuccess(null);
+
+    const search = nextMode === "register" ? "" : `?mode=${nextMode}`;
+    navigate(
+      {
+        pathname: location.pathname,
+        search,
+      },
+      { replace: true, state: location.state },
+    );
+  };
 
   const [form, setForm] = useState({
     name: "",
@@ -18,14 +76,28 @@ const Auth = () => {
     password: "",
     company: "",
     industry: "",
-    membership: "Hyperdrive" as const,
+    membership: membershipTiers[0].value as MembershipPlan,
   });
+
+  const membershipLabel = useMemo(() => {
+    return membershipTiers.find((tier) => tier.value === form.membership)?.label ?? "";
+  }, [form.membership]);
 
   useEffect(() => {
     if (user) {
       navigate(redirectPath, { replace: true });
     }
   }, [user, navigate, redirectPath]);
+
+  const resetForm = () =>
+    setForm({
+      name: "",
+      email: "",
+      password: "",
+      company: "",
+      industry: "",
+      membership: membershipTiers[0].value,
+    });
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -35,7 +107,7 @@ const Auth = () => {
 
     try {
       if (mode === "register") {
-        if (!form.name || !form.email || !form.password) {
+        if (!form.name || !form.email || !form.password || !form.company || !form.industry) {
           setError("Merci de remplir tous les champs indispensables.");
           return;
         }
@@ -43,15 +115,28 @@ const Auth = () => {
         const response = await registerUser(form);
         if (response.success) {
           setSuccess(response.message ?? "Compte créé avec succès. Vous êtes désormais connecté·e.");
+          resetForm();
         } else {
           setError(response.message ?? "Impossible de créer le compte.");
         }
-      } else {
+      } else if (mode === "login") {
         const response = await login(form.email, form.password);
         if (!response.success) {
           setError(response.message ?? "Impossible de se connecter.");
         } else {
           setSuccess("Connexion réussie. Vous pouvez préparer votre brief.");
+        }
+      } else {
+        if (!form.email) {
+          setError("Merci d'indiquer l'adresse email associée à votre compte.");
+          return;
+        }
+
+        const response = await requestPasswordReset(form.email);
+        if (!response.success) {
+          setError(response.message ?? "Impossible d'envoyer le lien de réinitialisation.");
+        } else {
+          setSuccess(response.message ?? "Email de réinitialisation envoyé. Pensez à vérifier vos spams.");
         }
       }
     } finally {
@@ -95,19 +180,49 @@ const Auth = () => {
           className="space-y-6 rounded-[3rem] border border-white/10 bg-white/10 p-10 shadow-[0_20px_100px_rgba(236,72,153,0.2)] visual-secondary-veil"
           onSubmit={handleSubmit}
         >
-          <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-slate-200/70">
-            <span>{mode === "register" ? "Créer un compte" : "Connexion"}</span>
-            <button
-              type="button"
-              onClick={() => {
-                setMode((prev) => (prev === "register" ? "login" : "register"));
-                setError(null);
-                setSuccess(null);
-              }}
-              className="rounded-full border border-white/20 px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-white"
-            >
-              {mode === "register" ? "J'ai déjà un compte" : "Créer un compte"}
-            </button>
+          <div className="flex flex-wrap items-center justify-between gap-3 text-[0.65rem] uppercase tracking-[0.3em] text-slate-200/70">
+            <span>
+              {mode === "register" ? "Créer un compte" : mode === "login" ? "Connexion" : "Mot de passe oublié"}
+            </span>
+            <div className="flex flex-wrap items-center gap-2">
+              <div className="flex overflow-hidden rounded-full border border-white/15 bg-white/10">
+                <button
+                  type="button"
+                  onClick={() => changeMode("register")}
+                  className={cn(
+                    "px-4 py-2 text-[0.65rem] font-semibold transition",
+                    mode === "register"
+                      ? "bg-white/25 text-slate-900"
+                      : "text-white/80 hover:text-white"
+                  )}
+                  aria-pressed={mode === "register"}
+                >
+                  S'inscrire
+                </button>
+                <button
+                  type="button"
+                  onClick={() => changeMode("login")}
+                  className={cn(
+                    "px-4 py-2 text-[0.65rem] font-semibold transition",
+                    mode === "login" ? "bg-white/25 text-slate-900" : "text-white/80 hover:text-white"
+                  )}
+                  aria-pressed={mode === "login"}
+                >
+                  Connexion
+                </button>
+              </div>
+              <button
+                type="button"
+                onClick={() => changeMode(mode === "forgot" ? "login" : "forgot")}
+                className={cn(
+                  "rounded-full border border-white/20 px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.3em] transition",
+                  mode === "forgot" ? "bg-white/20 text-slate-900" : "text-white"
+                )}
+                aria-pressed={mode === "forgot"}
+              >
+                Mot de passe oublié
+              </button>
+            </div>
           </div>
 
           {mode === "register" && (
@@ -141,3 +256,126 @@ const Auth = () => {
                     onChange={(event) => setForm((prev) => ({ ...prev, industry: event.target.value }))}
                     placeholder="Secteur d'activité"
                     required
+                  />
+                </div>
+              </div>
+              <div>
+                <p className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Formule sélectionnée</p>
+                <div className="mt-3 grid gap-3 sm:grid-cols-3">
+                  {membershipTiers.map((tier) => {
+                    const isActive = tier.value === form.membership;
+                    return (
+                      <button
+                        key={tier.value}
+                        type="button"
+                        onClick={() => setForm((prev) => ({ ...prev, membership: tier.value }))}
+                        className={cn(
+                          "rounded-2xl border bg-white/5 px-4 py-3 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300",
+                          isActive
+                            ? "border-cyan-300/80 bg-cyan-500/20 text-white shadow-[0_10px_40px_rgba(56,189,248,0.25)]"
+                            : "border-white/10 text-slate-100/80 hover:border-cyan-200/40 hover:bg-white/10"
+                        )}
+                        aria-pressed={isActive}
+                      >
+                        <span className="text-sm font-semibold uppercase tracking-[0.25em] text-cyan-100/80 visual-accent-text-strong">
+                          {tier.label}
+                        </span>
+                        <p className="mt-2 text-xs text-slate-200/80">{tier.tagline}</p>
+                        <p className="mt-1 text-[0.7rem] text-slate-300/70">{tier.description}</p>
+                      </button>
+                    );
+                  })}
+                </div>
+                <p className="mt-2 text-[0.7rem] text-slate-300/70">
+                  {membershipLabel} · ajustable à tout moment depuis le tableau de bord.
+                </p>
+              </div>
+            </div>
+          )}
+
+          <div className="space-y-4">
+            <div>
+              <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Adresse email</label>
+              <input
+                type="email"
+                className="mt-2 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                value={form.email}
+                onChange={(event) => setForm((prev) => ({ ...prev, email: event.target.value }))}
+                placeholder="vous@futurebrand.com"
+                required
+              />
+            </div>
+            {mode !== "forgot" ? (
+              <div>
+                <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Mot de passe</label>
+                <input
+                  type="password"
+                  className="mt-2 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                  value={form.password}
+                  onChange={(event) => setForm((prev) => ({ ...prev, password: event.target.value }))}
+                  placeholder={mode === "register" ? "Créer un mot de passe sécurisé" : "Votre mot de passe"}
+                  required
+                  minLength={8}
+                />
+                {mode === "register" && (
+                  <p className="mt-2 text-[0.7rem] text-slate-300/70">
+                    Au moins 8 caractères, une majuscule et un chiffre pour sécuriser votre espace client.
+                  </p>
+                )}
+                {mode === "login" && (
+                  <button
+                    type="button"
+                    onClick={() => changeMode("forgot")}
+                    className="mt-3 text-[0.7rem] font-semibold uppercase tracking-[0.3em] text-cyan-200/80 transition hover:text-cyan-100"
+                  >
+                    Mot de passe oublié ?
+                  </button>
+                )}
+              </div>
+            ) : (
+              <div className="rounded-2xl border border-white/15 bg-white/10 p-4 text-[0.75rem] text-slate-200/80">
+                <p>
+                  Saisissez l'adresse email associée à votre compte. Nous vous enverrons un lien pour choisir un nouveau mot de passe.
+                </p>
+              </div>
+            )}
+          </div>
+
+          {error && (
+            <p className="rounded-2xl border border-red-400/40 bg-red-500/10 px-4 py-3 text-sm text-red-200">{error}</p>
+          )}
+
+          {success && (
+            <p className="rounded-2xl border border-emerald-400/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-200">{success}</p>
+          )}
+
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className={cn(
+              "group relative w-full overflow-hidden rounded-full border border-cyan-200/40 bg-cyan-500/20 px-6 py-3 text-sm font-bold uppercase tracking-[0.3em] text-white transition",
+              isSubmitting && "cursor-not-allowed opacity-70"
+            )}
+          >
+            <span className="relative z-10">
+              {isSubmitting
+                ? "Traitement en cours..."
+                : mode === "register"
+                  ? "Créer mon espace"
+                  : mode === "login"
+                    ? "Me connecter"
+                    : "Envoyer le lien"}
+            </span>
+            <span className="absolute inset-0 translate-x-[-120%] bg-gradient-to-r from-cyan-400 via-sky-300 to-fuchsia-400 transition-transform duration-700 group-hover:translate-x-0" />
+          </button>
+
+          <p className="text-[0.7rem] text-slate-300/70">
+            En validant, vous acceptez les conditions générales Studio VBG et notre politique de confidentialité.
+          </p>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default Auth;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,7 +1,8 @@
 import { Link } from "react-router-dom";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useStudio } from "@/context/StudioContext";
 import { servicesData } from "@/lib/services";
+import { cn } from "@/lib/utils";
 
 const heroHooks = [
   "Votre direction attend des résultats tangibles : nous concevons des productions qui les démontrent.",
@@ -21,9 +22,11 @@ const techStack = [
 ];
 
 const Index = () => {
-  const { portfolioItems, recordContactRequest } = useStudio();
+  const { portfolioItems, recordContactRequest, user } = useStudio();
   const [hookIndex, setHookIndex] = useState(0);
   const [contactSent, setContactSent] = useState(false);
+  const [heroImageLoaded, setHeroImageLoaded] = useState(false);
+  const [heroImageError, setHeroImageError] = useState(false);
   const [form, setForm] = useState({
     name: "",
     email: "",
@@ -32,6 +35,11 @@ const Index = () => {
   });
 
   const heroProject = portfolioItems[0];
+
+  useEffect(() => {
+    setHeroImageLoaded(false);
+    setHeroImageError(false);
+  }, [heroProject?.thumbnail]);
 
   return (
     <div className="relative min-h-screen overflow-x-hidden bg-slate-950 text-white">
@@ -90,6 +98,16 @@ const Index = () => {
                 </span>
                 <span className="absolute inset-0 -z-0 translate-y-full bg-white/20 transition-all duration-500 group-hover:translate-y-0" />
               </a>
+              <Link
+                to={user ? "/dashboard" : "/auth"}
+                className="group relative overflow-hidden rounded-full border border-white/20 bg-white/10 px-8 py-4 text-sm font-bold uppercase tracking-[0.3em] text-white transition hover:scale-105"
+              >
+                <span className="relative z-10 flex items-center gap-3">
+                  <span className="text-xl">{user ? "📊" : "✨"}</span>
+                  {user ? "Tableau de bord" : "S'inscrire / Connexion"}
+                </span>
+                <span className="absolute inset-0 -z-0 translate-y-full bg-white/20 transition-all duration-500 group-hover:translate-y-0" />
+              </Link>
             </div>
             <div className="grid gap-4 text-sm text-slate-300/80 sm:grid-cols-2">
               <div className="rounded-3xl border border-white/10 bg-white/5 p-4 backdrop-blur">
@@ -118,11 +136,37 @@ const Index = () => {
                   <div className="rounded-2xl bg-white/5 p-3 text-center">{heroProject?.duration}</div>
                   <div className="rounded-2xl bg-white/5 p-3 text-center">{heroProject?.year}</div>
                 </div>
-                <img
-                  src={heroProject?.thumbnail}
-                  alt={heroProject?.title}
-                  className="h-64 w-full rounded-[2rem] object-cover object-center"
-                />
+                <div className="relative h-64 w-full overflow-hidden rounded-[2rem]">
+                  <div
+                    className={cn(
+                      "absolute inset-0 bg-gradient-to-br",
+                      heroProject?.gradient ?? "from-cyan-500 via-sky-500 to-indigo-600",
+                    )}
+                  />
+                  {!heroImageError && heroProject?.thumbnail ? (
+                    <img
+                      src={heroProject.thumbnail}
+                      alt={heroProject.title}
+                      onLoad={() => setHeroImageLoaded(true)}
+                      onError={() => setHeroImageError(true)}
+                      className={cn(
+                        "absolute inset-0 h-full w-full object-cover object-center transition-opacity duration-700",
+                        heroImageLoaded ? "opacity-100" : "opacity-0",
+                      )}
+                    />
+                  ) : (
+                    <div className="relative z-10 flex h-full w-full flex-col items-center justify-center gap-3 bg-slate-950/40 text-center">
+                      <span className="text-3xl">🎬</span>
+                      <p className="text-sm font-semibold uppercase tracking-[0.3em] text-white/70">
+                        Aperçu en cours de préparation
+                      </p>
+                      <p className="text-xs text-white/60">
+                        L'image du projet se charge avec un rendu dégradé artistique en attendant.
+                      </p>
+                    </div>
+                  )}
+                  <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-slate-950/40 via-transparent to-transparent" />
+                </div>
                 <div className="flex flex-wrap gap-2 text-xs text-cyan-100/80 visual-accent-text-strong">
                   {heroProject?.aiTools.map((tool) => (
                     <span key={tool} className="rounded-full bg-cyan-500/20 visual-accent-bg px-3 py-1">

--- a/src/pages/Portfolio.tsx
+++ b/src/pages/Portfolio.tsx
@@ -185,7 +185,7 @@ const Portfolio = () => {
             </nav>
           </header>
 
-          <div className="portfolio-gallery grid gap-6 sm:grid-cols-2 xl:grid-cols-4">
+          <div className="portfolio-gallery grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
             {filtered.map((project) => (
               <article
                 key={project.id}
@@ -203,39 +203,17 @@ const Portfolio = () => {
                 <div className="portfolio-card-media">
                   <img src={project.thumbnail} alt={project.title} className="h-full w-full object-cover object-center" />
                   <div className="portfolio-card-overlay" />
-                  <div className="portfolio-card-copy">
-                    <p className="text-[10px] uppercase tracking-[0.3em] text-cyan-100/70 visual-accent-text">{project.category}</p>
-                    <h2 className="text-xl font-semibold text-white">{project.title}</h2>
-                    <p className="text-xs text-slate-200/75">{project.tagline}</p>
-                  </div>
-                </div>
-                <div className="portfolio-card-meta text-xs text-slate-200/80">
-                  <div className="flex items-center justify-between text-[10px] uppercase tracking-[0.3em] text-slate-200/60">
+                  <div className="portfolio-card-top">
                     <span>{project.year}</span>
                     <span>{project.duration}</span>
                   </div>
-                  <div className="mt-4 flex flex-wrap gap-2 text-[11px] text-cyan-100/75 visual-accent-text-strong">
-                    {project.aiTools.slice(0, 3).map((tool) => (
-                      <span key={tool} className="rounded-full border border-white/15 bg-white/5 px-3 py-1">
-                        {tool}
-                      </span>
-                    ))}
-                    {project.aiTools.length > 3 && (
-                      <span className="rounded-full border border-white/20 px-3 py-1">+{project.aiTools.length - 3}</span>
-                    )}
+                  <div className="portfolio-card-copy">
+                    <p className="text-[10px] uppercase tracking-[0.3em] text-cyan-100/70 visual-accent-text">{project.category}</p>
+                    <h2 className="text-lg font-semibold text-white">{project.title}</h2>
+                    <p className="text-xs text-slate-200/80">{project.tagline}</p>
                   </div>
-                  <div className="mt-4 text-[11px] uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">
-                    Diffusions
-                  </div>
-                  <div className="mt-2 flex flex-wrap gap-2 text-[11px]">
-                    {project.socialStack.map((channel) => (
-                      <span key={channel} className="rounded-full border border-white/15 bg-white/5 px-3 py-1">
-                        {channel}
-                      </span>
-                    ))}
-                  </div>
+                  <div className="portfolio-card-cta">Ouvrir la capsule</div>
                 </div>
-                <div className="portfolio-card-cta">Ouvrir la capsule</div>
               </article>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- rework portfolio cards into compact 16:9 thumbnails with inline year and duration badges
- tighten the gallery grid to show four vignettes per row on large screens while keeping the hover cue inside the media frame
- remove pipeline and diffusion metadata from the preview tiles, limiting copy to the essentials

## Testing
- npm run lint *(emits existing react-refresh/only-export-components warnings)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4df87bb408328a0a372781911a614