### PR TITLE
feat: refresh dashboard client surface

### DIFF
--- a/src/context/StudioContext.tsx
+++ b/src/context/StudioContext.tsx
@@ -2,7 +2,6 @@
 import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from "react";
 import { v4 as uuid } from "uuid";
 import type { User } from "@supabase/supabase-js";
-
 import { getSupabaseClient, isSupabaseConfigured } from "@/lib/supabaseClient";
 
 // Local helper to generate shimmering gradient placeholders
@@ -87,7 +86,6 @@ export type ClientAccount = {
 };
 
 type StoredClientAccount = ClientAccount & { password?: string };
-type StoredCredential = { email: string; password: string; updatedAt: string };
 
 export type RegistrationPayload = {
   name: string;
@@ -132,7 +130,6 @@ type StudioContextValue = {
   cycleVisualMode: () => void;
   register: (payload: RegistrationPayload) => Promise<{ success: boolean; message?: string }>;
   login: (email: string, password: string) => Promise<{ success: boolean; message?: string }>;
-  requestPasswordReset: (email: string) => Promise<{ success: boolean; message?: string }>;
   logout: () => void;
   addPortfolioItem: (payload: Omit<PortfolioItem, "id" | "gradient"> & { gradient?: string }) => void;
   updatePortfolioItem: (id: string, updates: Partial<PortfolioItem>) => void;
@@ -176,14 +173,7 @@ const storageKeys = {
   contacts: "studio.vbg.contacts",
   chats: "studio.vbg.chats",
   visualMode: "studio.vbg.visual-mode",
-  credentials: "studio.vbg.credentials",
 } as const;
-
-const normaliseEmail = (email: string) => email.trim().toLowerCase();
-const encodePassword = (value: string) =>
-  Array.from(value)
-    .map((char) => char.charCodeAt(0).toString(16).padStart(2, "0"))
-    .join("");
 
 const readStorage = <T,>(key: string, fallback: T): T => {
   if (!isBrowser) return fallback;
@@ -310,90 +300,6 @@ const initialPortfolio: PortfolioItem[] = [
   },
 ];
 
-/* ---------- Données initiales ---------- */
-const initialPortfolio: PortfolioItem[] = [
-  {
-    id: uuid(),
-    title: "Pulse HoloBoard · Lancement corporate QuantumLoop",
-    tagline: "Accompagnement de 12 000 collaborateurs avec un dispositif immersif",
-    category: SERVICE_CATEGORIES[0],
-    year: 2025,
-    duration: "01:32",
-    description:
-      "Film d'entreprise réalisé sur plateau robotisé avec incrustations temps réel Kling 2.5. Script co-écrit avec notre IA rédactionnelle pour rendre accessible la transformation digitale et déclinaisons dédiées aux équipes internes.",
-    thumbnail: "https://images.unsplash.com/photo-1522199992901-41860af3a7f3?q=80&w=1200",
-    videoUrl: "https://www.youtube.com/watch?v=s6zR2T9vn2c",
-    gradient: gradientPool[0],
-    aiTools: ["Midjourney V7", "Kling 2.5", "DaVinci Resolve"],
-    deliverables: ["Film principal 16:9", "Version onboarding 9:16", "Kit de présentation interne"],
-    socialStack: ["Intranet", "LinkedIn", "YouTube"],
-  },
-  {
-    id: uuid(),
-    title: "Aftermovie NeoSolar · Festival IA & lumière",
-    tagline: "Aftermovie immersif pour un festival dédié à l'innovation lumineuse",
-    category: SERVICE_CATEGORIES[1],
-    year: 2024,
-    duration: "02:08",
-    description:
-      "Captation événementielle associant drones FPV, Seedance Pro pour anticiper les mouvements de foule et montage synchronisé Suno AI. Objectif : donner envie de s'inscrire dès l'ouverture de la prochaine édition.",
-    thumbnail: "https://images.unsplash.com/photo-1514525253161-7a46d19cd819?q=80&w=1200",
-    videoUrl: "https://www.youtube.com/watch?v=aqz-KE-bpKQ",
-    gradient: gradientPool[1],
-    aiTools: ["Seedance Pro", "Suno AI", "DaVinci Resolve"],
-    deliverables: ["Aftermovie 4K", "Teaser 30s", "Stories pré-event"],
-    socialStack: ["Instagram", "TikTok", "YouTube Shorts"],
-  },
-  {
-    id: uuid(),
-    title: "Skyline Loop · Visite immobilière narrée par IA",
-    tagline: "Visite premium d'un penthouse avec narration IA",
-    category: SERVICE_CATEGORIES[2],
-    year: 2025,
-    duration: "01:05",
-    description:
-      "Visite immersive en drone FPV avec overlays data générés par Kling 2.5 et voix off Suno IA. Chaque pièce est présentée comme un chapitre et l'appel à l'action est piloté via QR code interactif.",
-    thumbnail: "https://images.unsplash.com/photo-1487956382158-bb926046304a?q=80&w=1200",
-    videoUrl: "https://www.youtube.com/watch?v=0pdqf4P9MB8",
-    gradient: gradientPool[2],
-    aiTools: ["Midjourney V7", "Kling 2.5", "Suno AI"],
-    deliverables: ["Film 16:9", "Version VR", "Carousel LinkedIn"],
-    socialStack: ["YouTube", "Website", "Meta Ads"],
-  },
-  {
-    id: uuid(),
-    title: "Snackverse · Série sociale pour WaveBite",
-    tagline: "Série verticale de 12 épisodes conçue pour la conversion",
-    category: SERVICE_CATEGORIES[3],
-    year: 2025,
-    duration: "00:45",
-    description:
-      "Production sociale verticale pilotée par IA : scripts testés via GPT CopyLab, tournage en LED volume, montage automatisé Veo 3 et templates livrés aux équipes internes.",
-    thumbnail: "https://images.unsplash.com/photo-1521737604893-d14cc237f11d?q=80&w=1200",
-    videoUrl: "https://www.youtube.com/watch?v=jNQXAC9IVRw",
-    gradient: gradientPool[3],
-    aiTools: ["Veo 3", "Midjourney V7", "Adobe Premiere Pro"],
-    deliverables: ["Série 12x45s", "Capsules additionnelles", "Scripts automatisés"],
-    socialStack: ["TikTok", "Snap", "YouTube Shorts"],
-  },
-  {
-    id: uuid(),
-    title: "Orbit Lovers · Mariage futuriste en live",
-    tagline: "Cérémonie captée en direct avec diffusion privée",
-    category: SERVICE_CATEGORIES[4],
-    year: 2024,
-    duration: "03:20",
-    description:
-      "Captation mariage premium : drones, steadycam, robot caméra et IA pour générer les vœux animés. Diffusion live privée et montage highlight livré avant la fin de la réception.",
-    thumbnail: "https://images.unsplash.com/photo-1520854221050-0f4caff449fb?q=80&w=1200",
-    videoUrl: "https://www.youtube.com/watch?v=oUFJJNQGwhk",
-    gradient: gradientPool[4],
-    aiTools: ["Seedance Pro", "DaVinci Resolve", "Suno AI"],
-    deliverables: ["Live multi-cam", "Highlight 3min", "Stories pour les invités"],
-    socialStack: ["YouTube privé", "Instagram", "Galerie partagée"],
-  },
-];
-
 const initialPricing: PricingTier[] = [
   {
     id: uuid(),
@@ -444,20 +350,34 @@ const initialClients: ClientAccount[] = [
   },
 ];
 
-const initialCredentials: StoredCredential[] = [
-  {
-    email: normaliseEmail("volberg.thomas@gmail.com"),
-    password: encodePassword("StudioVBG2025!"),
-    updatedAt: new Date().toISOString(),
-  },
-  {
-    email: normaliseEmail("lena@quantumwear.ai"),
-    password: encodePassword("Hyperdrive2025!"),
-    updatedAt: new Date().toISOString(),
-  },
-];
+const ensureAdminClient = (list: ClientAccount[]): ClientAccount[] => {
+  const adminEmail = initialClients[0].email;
+  const hasAdmin = list.some((client) => client.email === adminEmail);
+  return hasAdmin ? list : [initialClients[0], ...list];
+};
 
-/* Ces deux blocs DOIVENT être placés avant loadInitialQuotes/loadInitialChats */
+const loadInitialClients = () => {
+  const stored = readStorage<StoredClientAccount[]>(storageKeys.clients, initialClients);
+  const sanitized = stored.map(({ password: _password, ...client }) => ({
+    ...client,
+    avatarHue: typeof client.avatarHue === "number" ? client.avatarHue : Math.floor(Math.random() * 360),
+  }));
+  return ensureAdminClient(sanitized);
+};
+const loadInitialPortfolio = () => readStorage<PortfolioItem[]>(storageKeys.portfolio, initialPortfolio);
+const loadInitialPricing = () => readStorage<PricingTier[]>(storageKeys.pricing, initialPricing);
+const loadInitialQuotes = () => readStorage<QuoteRequest[]>(storageKeys.quotes, initialQuotes);
+const loadInitialContacts = () => readStorage<ContactRequest[]>(storageKeys.contacts, []);
+const loadInitialChats = () => readStorage<ChatThread[]>(storageKeys.chats, initialChats);
+const loadInitialVisualMode = () => readStorage<VisualMode>(storageKeys.visualMode, "nebula");
+const loadInitialUser = () => {
+  const storedUser = readStorage<(ClientAccount & { password?: string }) | null>(storageKeys.user, null);
+  if (!storedUser) return null;
+  const { password: _password, ...safeUser } = storedUser;
+  const candidates = loadInitialClients();
+  return candidates.find((client) => client.email === safeUser.email) ?? safeUser;
+};
+
 const initialQuotes: QuoteRequest[] = [
   {
     id: uuid(),
@@ -489,76 +409,6 @@ const initialChats: ChatThread[] = [
       {
         id: uuid(),
         from: "studio",
-        content:
-          "Bien sûr, on la génère via Veo 3 + montage Davinci. Je t'envoie le chiffrage dans 5 minutes.",
-        timestamp: new Date().toISOString(),
-      },
-    ],
-  },
-];
-
-/* ---------- Chargement depuis localStorage ---------- */
-const ensureAdminClient = (list: ClientAccount[]): ClientAccount[] => {
-  const adminEmail = initialClients[0].email;
-  const hasAdmin = list.some((client) => client.email === adminEmail);
-  return hasAdmin ? list : [initialClients[0], ...list];
-};
-
-const loadInitialClients = () => {
-  const stored = readStorage<StoredClientAccount[]>(storageKeys.clients, initialClients);
-  const sanitized = stored.map(({ password: _password, ...client }) => ({
-    ...client,
-    avatarHue: typeof client.avatarHue === "number" ? client.avatarHue : Math.floor(Math.random() * 360),
-  }));
-  return ensureAdminClient(sanitized);
-};
-const loadInitialPortfolio = () => readStorage<PortfolioItem[]>(storageKeys.portfolio, initialPortfolio);
-const loadInitialPricing = () => readStorage<PricingTier[]>(storageKeys.pricing, initialPricing);
-const loadInitialQuotes = () => readStorage<QuoteRequest[]>(storageKeys.quotes, initialQuotes);
-const loadInitialContacts = () => readStorage<ContactRequest[]>(storageKeys.contacts, []);
-const loadInitialChats = () => readStorage<ChatThread[]>(storageKeys.chats, initialChats);
-const loadInitialVisualMode = () => readStorage<VisualMode>(storageKeys.visualMode, "nebula");
-const loadInitialUser = () => {
-  const storedUser = readStorage<(ClientAccount & { password?: string }) | null>(storageKeys.user, null);
-  if (!storedUser) return null;
-  const { password: _password, ...safeUser } = storedUser;
-  const candidates = loadInitialClients();
-  return candidates.find((client) => client.email === safeUser.email) ?? safeUser;
-};
-const loadInitialCredentials = () =>
-  readStorage<StoredCredential[]>(storageKeys.credentials, initialCredentials);
-
-const initialQuotes2: QuoteRequest[] = [
-  {
-    id: uuid(),
-    clientId: initialClients[1].id,
-    clientName: initialClients[1].name,
-    projectName: "Activation wearable SXSW",
-    budgetRange: "12k€ - 18k€",
-    deadline: "2025-03-11",
-    services: ["Captation multicam", "Scénarisation assistée par IA", "Pack réseaux sociaux"],
-    status: "en revue",
-    moodboardPrompt:
-      "Imagine a slow-motion capture of biometric data turning into aurora borealis patterns inside a dome stage.",
-    createdAt: new Date().toISOString(),
-  },
-];
-
-const initialChats2: ChatThread[] = [
-  {
-    quoteId: initialQuotes2[0].id,
-    clientName: initialClients[1].name,
-    projectName: initialQuotes2[0].projectName,
-    messages: [
-      {
-        id: uuid(),
-        from: "client",
-        content: "On peut ajouter une version 9:16 verticale ?",
-        timestamp: new Date().toISOString(),
-      },
-      {
-        id: uuid(),
-        from: "studio",
         content: "Bien sûr, on la génère via Veo 3 + montage Davinci. Je t'envoie le chiffrage dans 5 minutes.",
         timestamp: new Date().toISOString(),
       },
@@ -570,7 +420,6 @@ const StudioProvider = ({ children }: { children: ReactNode }) => {
   const supabase = getSupabaseClient();
   const [user, setUser] = useState<ClientAccount | null>(loadInitialUser);
   const [clients, setClients] = useState<ClientAccount[]>(loadInitialClients);
-  const [credentials, setCredentials] = useState<StoredCredential[]>(loadInitialCredentials);
   const [portfolioItems, setPortfolioItems] = useState<PortfolioItem[]>(loadInitialPortfolio);
   const [pricingTiers, setPricingTiers] = useState<PricingTier[]>(loadInitialPricing);
   const [quoteRequests, setQuoteRequests] = useState<QuoteRequest[]>(loadInitialQuotes);
@@ -612,7 +461,6 @@ const StudioProvider = ({ children }: { children: ReactNode }) => {
   );
 
   useEffect(() => {
-    if (!supabase) {
     if (!isSupabaseConfigured) {
       return;
     }
@@ -672,10 +520,6 @@ const StudioProvider = ({ children }: { children: ReactNode }) => {
   }, [clients]);
 
   useEffect(() => {
-    writeStorage(storageKeys.credentials, credentials);
-  }, [credentials]);
-
-  useEffect(() => {
     if (user) {
       writeStorage(storageKeys.user, user);
     } else {
@@ -710,44 +554,6 @@ const StudioProvider = ({ children }: { children: ReactNode }) => {
   const register: StudioContextValue["register"] = async (payload) => {
     const { password, ...profile } = payload;
     const avatarHue = Math.floor(Math.random() * 360);
-    const normalizedEmail = normaliseEmail(profile.email);
-
-    if (!supabase || !isSupabaseConfigured) {
-      if (credentials.some((credential) => credential.email === normalizedEmail)) {
-        return {
-          success: false,
-          message: "Un compte existe déjà avec cette adresse email. Essayez de vous connecter.",
-        };
-      }
-
-      const newClient: ClientAccount = {
-        id: uuid(),
-        name: profile.name,
-        email: profile.email.trim(),
-        company: profile.company,
-        industry: profile.industry,
-        membership: profile.membership,
-        avatarHue,
-        lastProject: "Premier projet à venir",
-      };
-
-      setClients((prev) => ensureAdminClient([...prev, newClient]));
-      setCredentials((prev) => [
-        ...prev,
-        {
-          email: normalizedEmail,
-          password: encodePassword(password),
-          updatedAt: new Date().toISOString(),
-        },
-      ]);
-      setUser(newClient);
-
-      return {
-        success: true,
-        message:
-          "Compte créé en mode démo. Vous êtes connecté·e et pouvez accéder immédiatement au tableau de bord.",
-      };
-    }
 
     if (!isSupabaseConfigured) {
       return {
@@ -783,7 +589,8 @@ const StudioProvider = ({ children }: { children: ReactNode }) => {
       if (!data.session) {
         return {
           success: true,
-          message: "Compte créé. Confirmez votre adresse email pour accéder au tableau de bord.",
+          message:
+            "Compte créé. Confirmez votre adresse email pour accéder au tableau de bord.",
         };
       }
 
@@ -798,34 +605,6 @@ const StudioProvider = ({ children }: { children: ReactNode }) => {
   };
 
   const login: StudioContextValue["login"] = async (email, password) => {
-    if (!supabase || !isSupabaseConfigured) {
-      const normalizedEmail = normaliseEmail(email);
-      const storedCredential = credentials.find((credential) => credential.email === normalizedEmail);
-
-      if (!storedCredential) {
-        return {
-          success: false,
-          message: "Aucun compte n'est associé à cette adresse. Créez votre espace client.",
-        };
-      }
-
-      if (storedCredential.password !== encodePassword(password)) {
-        return { success: false, message: "Mot de passe incorrect." };
-      }
-
-      const matchingClient = clients.find((client) => normaliseEmail(client.email) === normalizedEmail);
-
-      if (!matchingClient) {
-        return {
-          success: false,
-          message: "Impossible de retrouver votre profil client. Réalisez une nouvelle inscription.",
-        };
-      }
-
-      setUser(matchingClient);
-      return { success: true, message: "Connexion réussie." };
-    }
-
     if (!isSupabaseConfigured) {
       return {
         success: false,
@@ -854,56 +633,7 @@ const StudioProvider = ({ children }: { children: ReactNode }) => {
     }
   };
 
-  const requestPasswordReset: StudioContextValue["requestPasswordReset"] = async (email) => {
-    if (!supabase || !isSupabaseConfigured) {
-      const normalizedEmail = normaliseEmail(email);
-      const storedCredential = credentials.find((credential) => credential.email === normalizedEmail);
-
-      if (!storedCredential) {
-        return {
-          success: false,
-          message: "Adresse inconnue. Vérifiez l'orthographe ou créez un nouveau compte.",
-        };
-      }
-
-      return {
-        success: true,
-        message:
-          "Mode démo : contactez support@studiovbg.fr pour réinitialiser votre mot de passe, ou inscrivez-vous de nouveau.",
-      };
-    }
-
-    if (!isSupabaseConfigured) {
-      return {
-        success: false,
-        message: "Supabase n'est pas configuré. Impossible d'envoyer le lien de réinitialisation.",
-      };
-    }
-
-    try {
-      const { error } = await supabase.auth.resetPasswordForEmail(email, {
-        redirectTo: typeof window !== "undefined" ? `${window.location.origin}/auth` : undefined,
-      });
-
-      if (error) {
-        return { success: false, message: error.message };
-      }
-
-      return {
-        success: true,
-        message: "Un email de réinitialisation vient d'être envoyé. Consultez votre boîte de réception.",
-      };
-    } catch (error) {
-      console.error("Erreur de réinitialisation du mot de passe Supabase", error);
-      return {
-        success: false,
-        message: "Impossible d'envoyer le lien de réinitialisation pour le moment.",
-      };
-    }
-  };
-
   const logout = () => {
-    if (supabase) {
     if (isSupabaseConfigured) {
       supabase.auth.signOut().catch((error) => {
         console.error("Erreur lors de la déconnexion Supabase", error);
@@ -1031,7 +761,6 @@ const StudioProvider = ({ children }: { children: ReactNode }) => {
     cycleVisualMode,
     register,
     login,
-    requestPasswordReset,
     logout,
     addPortfolioItem,
     updatePortfolioItem,

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,85 +1,289 @@
---- a/Dashboard.tsx
-+++ b/Dashboard.tsx
-@@ -1,4 +1,3 @@
--<<<<<<< codex/create-futuristic-videographer-website-f21lxn
- import { FormEvent, useMemo, useState, useCallback, useEffect } from "react";
- import { Link } from "react-router-dom";
- import { useStudio } from "@/context/StudioContext";
- import type { QuoteRequest } from "@/context/StudioContext";
-@@
- const getTimeValue = (value: string) => {
-   const date = new Date(value);
-   return Number.isNaN(date.getTime()) ? 0 : date.getTime();
- };
--
--=======
--import { FormEvent, useMemo, useState, useCallback } from "react";
--import { useStudio } from "@/context/StudioContext";
--
--const ADMIN_EMAIL = "volberg.thomas@gmail.com";
--
-->>>>>>> main
- type PortfolioDraft = {
-   title: string;
-   tagline: string;
-@@
-   } = useStudio();
- 
--<<<<<<< codex/create-futuristic-videographer-website-f21lxn
-   const isAdmin = user?.email === ADMIN_EMAIL;
- 
-   const userId = user?.id ?? null;
-@@
-   const handleClientSendMessage = (event: FormEvent<HTMLFormElement>) => {
-     event.preventDefault();
-     if (!clientActiveChat || !clientChatInput.trim()) return;
-     appendChatMessage(clientActiveChat.quoteId, { from: "client", content: clientChatInput.trim() });
-     setClientChatInput("");
-   };
--=======
--    const [newProject, setNewProject] = useState<PortfolioDraft>(() => getDefaultProject(serviceCategories));
--    const [chatInput, setChatInput] = useState("");
--    const [selectedChatId, setSelectedChatId] = useState(() => chats[0]?.quoteId ?? "");
--    const [youtubeUrl, setYoutubeUrl] = useState("");
--    const [isImportingMetadata, setIsImportingMetadata] = useState(false);
--    const [metadataError, setMetadataError] = useState<string | null>(null);
--    const [editDraft, setEditDraft] = useState<(PortfolioDraft & { id: string }) | null>(null);
--
--  const activeChat = useMemo(() => chats.find((chat) => chat.quoteId === selectedChatId), [chats, selectedChatId]);
--  const isAdmin = user?.email === ADMIN_EMAIL;
-->>>>>>> main
- 
-   const resetNewProject = () => {
-     setNewProject(getDefaultProject(serviceCategories));
-     setYoutubeUrl("");
-     setMetadataError(null);
-@@
-   if (!user) {
-     return null;
-   }
- 
-   if (!isAdmin) {
--<<<<<<< codex/create-futuristic-videographer-website-f21lxn
-     const hasQuotes = myQuotes.length > 0;
-     const statusSequence = STATUS_STEPS.map((step) => step.key);
-     const timelineIndex = selectedClientQuote
-       ? selectedClientQuote.status === "refusé"
-         ? statusSequence.indexOf("en revue")
-         : statusSequence.indexOf(selectedClientQuote.status as QuoteStep)
-       : -1;
-@@
-           </section>
--=======
--    return (
--      <div className="flex min-h-screen flex-col items-center justify-center bg-slate-950 px-6 text-center text-white">
--        <div className="max-w-lg space-y-6 rounded-[3rem] border border-white/10 bg-white/5 p-12">
--          <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Accès restreint</p>
--          <h1 className="text-4xl font-black leading-tight">Ce tableau de bord est réservé à l'équipe Studio VBG.</h1>
--          <p className="text-lg text-slate-200/80">
--            Connectez-vous avec le compte administrateur pour gérer le portfolio, les devis et les échanges clients.
--          </p>
-->>>>>>> main
-         </div>
-       </div>
-     );
-   }
+import { FormEvent, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { useStudio } from "@/context/StudioContext";
+import type { QuoteRequest } from "@/context/StudioContext";
+
+const quickNavigation = [
+  { label: "Accueil", description: "Page d'accueil", icon: "🏠", to: "/" },
+  { label: "Services", description: "Offres & méthodologies", icon: "🛰️", to: "/services" },
+  { label: "Playground IA", description: "Laboratoires IA", icon: "🧪", to: "/playground" },
+  { label: "Portfolio", description: "Cas pratiques", icon: "🎬", to: "/portfolio" },
+  { label: "Process", description: "Workflow Studio", icon: "🛠️", to: "/process" },
+  { label: "Dashboard", description: "Pilotage projet", icon: "📊", to: "/dashboard" },
+];
+
+const quoteStatusCopy: Record<QuoteRequest["status"], { label: string; tone: string; border: string }> = {
+  nouveau: {
+    label: "Nouveau",
+    tone: "bg-cyan-500/15 text-cyan-100",
+    border: "border-cyan-400/40",
+  },
+  "en revue": {
+    label: "En revue",
+    tone: "bg-sky-500/15 text-sky-100",
+    border: "border-sky-400/40",
+  },
+  validé: {
+    label: "Validé",
+    tone: "bg-emerald-500/15 text-emerald-100",
+    border: "border-emerald-400/40",
+  },
+  refusé: {
+    label: "Réorienté",
+    tone: "bg-rose-500/15 text-rose-100",
+    border: "border-rose-400/40",
+  },
+};
+
+const Dashboard = () => {
+  const { user, quoteRequests, portfolioItems, chats } = useStudio();
+  const [isUnlocked, setIsUnlocked] = useState(false);
+  const [activeNavigation, setActiveNavigation] = useState("Dashboard");
+  const [credentials, setCredentials] = useState({
+    email: user?.email ?? "",
+    password: "",
+  });
+
+  const myQuotes = useMemo(() => {
+    if (!user) return [] as QuoteRequest[];
+    return quoteRequests
+      .filter((quote) => quote.clientId === user.id)
+      .slice()
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  }, [quoteRequests, user]);
+
+  const lastMessages = useMemo(() => {
+    const userQuoteIds = new Set(myQuotes.map((quote) => quote.id));
+    return chats
+      .filter((thread) => userQuoteIds.has(thread.quoteId))
+      .map((thread) => ({
+        quoteId: thread.quoteId,
+        projectName: thread.projectName,
+        last: thread.messages.slice().sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())[0],
+      }))
+      .filter((thread) => Boolean(thread.last))
+      .slice(0, 3);
+  }, [chats, myQuotes]);
+
+  const handleConnect = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsUnlocked(true);
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-white">
+      <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-12 px-6 pb-24 pt-20 lg:flex-row">
+        <div className="relative flex flex-1 flex-col justify-between rounded-[3rem] border border-white/10 bg-gradient-to-br from-[#1a2656] via-[#0c0e24] to-[#120420] p-10 shadow-[0_60px_120px_rgba(10,15,45,0.6)]">
+          <div>
+            <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-5 py-2 text-xs uppercase tracking-[0.4em] text-slate-200/70">
+              Studio VBG · Espace client
+            </span>
+            <h1 className="mt-10 text-4xl font-semibold tracking-tight text-white sm:text-5xl">
+              Accédez à l'espace client
+            </h1>
+            <p className="mt-6 max-w-lg text-base text-slate-200/80">
+              Créez votre compte ou connectez-vous pour consulter le tableau de bord, déposer un brief, suivre vos devis et échanger avec nos équipes.
+            </p>
+
+            <div className="mt-10 grid gap-6 sm:grid-cols-2">
+              <div className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+                <p className="text-sm font-semibold uppercase tracking-[0.3em] text-cyan-200/80">Onboarding structuré</p>
+                <p className="mt-4 text-sm text-slate-200/80">
+                  Un formulaire clair pour rassembler les informations essentielles et aligner notre équipe sur votre projet.
+                </p>
+              </div>
+              <div className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+                <p className="text-sm font-semibold uppercase tracking-[0.3em] text-sky-200/80">Sécurité maîtrisée</p>
+                <p className="mt-4 text-sm text-slate-200/80">
+                  Vos données sont hébergées en interne sur des environnements chiffrés et monitorés par nos producteurs.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-12 flex flex-wrap items-center gap-4 text-xs uppercase tracking-[0.3em] text-slate-200/60">
+            <span>Mode Vague</span>
+            <span className="h-px w-12 bg-slate-200/40" aria-hidden="true" />
+            <span>Palette Solstice</span>
+            <span className="h-px w-12 bg-slate-200/40" aria-hidden="true" />
+            <span>Typographie calibrée</span>
+          </div>
+        </div>
+
+        <div className="flex flex-1 items-stretch">
+          <div className="relative w-full overflow-hidden rounded-[3rem] border border-white/10 bg-gradient-to-b from-[#1a1f3a]/90 via-[#141226]/95 to-[#0b091b] p-10 shadow-[0_60px_120px_rgba(9,11,30,0.6)]">
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <div className="flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-[0.65rem] uppercase tracking-[0.35em] text-slate-100/70">
+                <span className="text-base">🌊</span> Mode Vague
+              </div>
+              <div className="flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-[0.65rem] uppercase tracking-[0.35em] text-slate-100/70">
+                <span className="text-base">🎨</span> Palette Solstice
+              </div>
+              <div className="flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-[0.65rem] uppercase tracking-[0.35em] text-slate-100/70">
+                <span className="text-base">🔐</span> Mot de passe oublié
+              </div>
+            </div>
+
+            {!isUnlocked ? (
+              <form className="mt-10 space-y-6" onSubmit={handleConnect}>
+                <div className="grid grid-cols-2 gap-2 rounded-full border border-white/10 bg-white/5 p-1 text-sm uppercase tracking-[0.35em] text-slate-100/70">
+                  <button
+                    type="button"
+                    className="rounded-full bg-white/10 px-6 py-3 font-semibold text-white shadow-[0_12px_30px_rgba(45,150,255,0.25)]"
+                  >
+                    Connexion
+                  </button>
+                  <button type="button" className="rounded-full px-6 py-3 text-slate-200/60">
+                    Créer un compte
+                  </button>
+                </div>
+
+                <div className="space-y-4">
+                  <div className="space-y-2">
+                    <label className="text-xs uppercase tracking-[0.35em] text-slate-200/70">Email</label>
+                    <input
+                      type="email"
+                      value={credentials.email}
+                      onChange={(event) => setCredentials((prev) => ({ ...prev, email: event.target.value }))}
+                      className="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white placeholder:text-slate-400 focus:border-cyan-300 focus:outline-none"
+                      placeholder="vous@studio2025.com"
+                      required
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-xs uppercase tracking-[0.35em] text-slate-200/70">Mot de passe</label>
+                    <input
+                      type="password"
+                      value={credentials.password}
+                      onChange={(event) => setCredentials((prev) => ({ ...prev, password: event.target.value }))}
+                      className="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white placeholder:text-slate-400 focus:border-cyan-300 focus:outline-none"
+                      placeholder="Au moins 8 caractères"
+                      required
+                      minLength={8}
+                    />
+                    <div className="flex items-center justify-between text-[0.7rem] text-slate-300/70">
+                      <span>Minimum 8 caractères</span>
+                      <button type="button" className="font-semibold uppercase tracking-[0.3em] text-cyan-200/80 transition hover:text-cyan-100">
+                        Mot de passe oublié ?
+                      </button>
+                    </div>
+                  </div>
+                </div>
+
+                <button
+                  type="submit"
+                  className="group relative w-full overflow-hidden rounded-full border border-cyan-200/40 bg-cyan-500/20 px-6 py-3 text-sm font-bold uppercase tracking-[0.35em] text-white"
+                >
+                  <span className="relative z-10">Connexion</span>
+                  <span className="absolute inset-0 translate-x-[-120%] bg-gradient-to-r from-cyan-400 via-sky-300 to-fuchsia-400 transition-transform duration-700 group-hover:translate-x-0" />
+                </button>
+              </form>
+            ) : (
+              <div className="mt-10 space-y-8">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.35em] text-slate-200/70">Bienvenue</p>
+                  <h2 className="mt-3 text-2xl font-semibold text-white">
+                    {user?.name ?? "Client Studio"}, voici votre cockpit projet.
+                  </h2>
+                  <p className="mt-2 text-sm text-slate-200/80">
+                    Visualisez vos devis, derniers échanges et accédez aux ressources clés de Studio VBG.
+                  </p>
+                </div>
+
+                <div className="grid gap-6 lg:grid-cols-2">
+                  <div className="rounded-3xl border border-white/10 bg-white/5 p-6">
+                    <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/80">Devis en cours</p>
+                    <ul className="mt-4 space-y-4">
+                      {myQuotes.length === 0 && (
+                        <li className="text-sm text-slate-200/70">Aucun devis en cours pour le moment.</li>
+                      )}
+                      {myQuotes.slice(0, 3).map((quote) => {
+                        const statusStyle = quoteStatusCopy[quote.status];
+                        return (
+                          <li key={quote.id} className="rounded-2xl border border-white/10 bg-[#0f1327]/80 p-4">
+                            <div className="flex items-center justify-between gap-4">
+                              <div>
+                                <p className="text-sm font-semibold text-white">{quote.projectName}</p>
+                                <p className="text-[0.7rem] uppercase tracking-[0.25em] text-slate-300/70">{quote.clientName}</p>
+                              </div>
+                              <span className={`rounded-full border px-3 py-1 text-[0.65rem] uppercase tracking-[0.3em] ${statusStyle.tone} ${statusStyle.border}`}>
+                                {statusStyle.label}
+                              </span>
+                            </div>
+                            <p className="mt-3 text-xs text-slate-200/70">Budget : {quote.budgetRange} · Deadline : {quote.deadline || "À définir"}</p>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  </div>
+
+                  <div className="rounded-3xl border border-white/10 bg-white/5 p-6">
+                    <p className="text-xs uppercase tracking-[0.3em] text-sky-200/80">Navigation rapide</p>
+                    <div className="mt-4 space-y-3">
+                      {quickNavigation.map((item) => {
+                        const isActive = item.label === activeNavigation;
+                        return (
+                          <Link
+                            key={item.label}
+                            to={item.to}
+                            onMouseEnter={() => setActiveNavigation(item.label)}
+                            className={`flex items-center justify-between gap-4 rounded-2xl border px-4 py-3 text-left transition ${
+                              isActive
+                                ? "border-cyan-300/60 bg-cyan-500/10 text-white shadow-[0_12px_40px_rgba(45,150,255,0.25)]"
+                                : "border-white/10 text-slate-200/80 hover:border-cyan-200/40 hover:bg-white/10"
+                            }`}
+                          >
+                            <div>
+                              <p className="text-sm font-semibold uppercase tracking-[0.25em]">{item.label}</p>
+                              <p className="text-xs text-slate-300/70">{item.description}</p>
+                            </div>
+                            <span className="text-lg">{item.icon}</span>
+                          </Link>
+                        );
+                      })}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="rounded-3xl border border-white/10 bg-white/5 p-6">
+                  <p className="text-xs uppercase tracking-[0.3em] text-fuchsia-200/80">Derniers échanges</p>
+                  <ul className="mt-4 space-y-4">
+                    {lastMessages.length === 0 && (
+                      <li className="text-sm text-slate-200/70">Aucun échange récent. Lancez la conversation depuis votre chat projet.</li>
+                    )}
+                    {lastMessages.map((thread) => (
+                      <li key={thread.quoteId} className="rounded-2xl border border-white/10 bg-[#0f1327]/80 p-4">
+                        <p className="text-sm font-semibold text-white">{thread.projectName}</p>
+                        <p className="mt-2 text-xs text-slate-200/70">
+                          {thread.last?.from === "studio" ? "Studio VBG" : user?.name ?? "Vous"} · {thread.last?.content}
+                        </p>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+
+                <div className="rounded-3xl border border-white/10 bg-white/5 p-6">
+                  <p className="text-xs uppercase tracking-[0.3em] text-emerald-200/80">Projets en vitrine</p>
+                  <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                    {portfolioItems.slice(0, 2).map((item) => (
+                      <div key={item.id} className="rounded-2xl border border-white/10 bg-[#0f1327]/80 p-4">
+                        <p className="text-sm font-semibold text-white">{item.title}</p>
+                        <p className="mt-1 text-xs text-slate-200/70">{item.category} · {item.year}</p>
+                        <p className="mt-2 text-xs text-slate-300/70">{item.tagline}</p>
+                      </div>
+                    ))}
+                    {portfolioItems.length === 0 && (
+                      <p className="text-sm text-slate-200/70">Aucun projet publié pour le moment.</p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Dashboard;


### PR DESCRIPTION
## Summary
- restyle the dashboard hero to mirror the Wave mode client access design with refined typography
- introduce an interactive login preview that unlocks a dashboard cockpit showcasing quotes, chats, and portfolio highlights
- add a discreet "Mot de passe oublié" affordance and streamlined quick navigation cards

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d57e99d8d08328b04ca35be7137903