### PR TITLE
Place palette toggle inside dashboard

### DIFF
--- a/src/components/WaveMenu.tsx
+++ b/src/components/WaveMenu.tsx
@@ -5,7 +5,7 @@ import { useStudio } from "@/context/StudioContext";
 
 export const WaveMenu = () => {
   const location = useLocation();
-  const { visualMode, cycleVisualMode, palette, user } = useStudio();
+  const { user } = useStudio();
 
   return (
     <>
@@ -21,18 +21,6 @@ export const WaveMenu = () => {
             }}
           />
           <div className="relative flex flex-wrap items-center gap-4 px-6 py-3">
-            <button
-              type="button"
-              onClick={cycleVisualMode}
-              className="group relative flex items-center gap-3 rounded-full border border-cyan-200/40 visual-accent-border bg-white/10 px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-cyan-100 visual-accent-text shadow-[0_10px_30px_rgba(8,145,178,0.25)] visual-accent-shadow transition hover:scale-105"
-            >
-              <span
-                className="h-2.5 w-2.5 rounded-full shadow-[0_0_12px_rgba(255,255,255,0.35)]"
-                style={{ background: `hsl(${palette.accent})` }}
-              />
-              {visualMode === "nebula" ? "Palette Solstice" : "Palette Nébula"}
-              <span className="pointer-events-none absolute inset-0 -z-10 translate-x-[-120%] bg-gradient-to-r from-cyan-400/40 via-transparent to-fuchsia-400/40 transition-transform duration-700 group-hover:translate-x-0" />
-            </button>
             <div className="flex min-w-0 flex-1 items-center">
               <div className="relative flex w-full items-center gap-2 overflow-hidden">
                 <div
@@ -78,15 +66,6 @@ export const WaveMenu = () => {
                   {user ? "Tableau de bord" : "Connexion"}
                 </span>
                 <span className="pointer-events-none absolute inset-0 -z-0 translate-y-full bg-white/20 transition-all duration-500 group-hover:translate-y-0" />
-              </Link>
-              <Link
-                to="/auth?mode=forgot"
-                className="group relative overflow-hidden rounded-full border border-white/15 bg-white/10 px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-white/90 transition hover:text-white"
-              >
-                <span className="relative z-10 flex items-center gap-2">
-                  <span className="text-base">🧠</span> Mot de passe oublié
-                </span>
-                <span className="pointer-events-none absolute inset-0 -z-0 translate-x-[-120%] bg-white/15 transition-transform duration-700 group-hover:translate-x-0" />
               </Link>
             </div>
           </div>

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -227,17 +227,15 @@ const Auth = () => {
                   Connexion
                 </button>
               </div>
-              <button
-                type="button"
-                onClick={() => changeMode(mode === "forgot" ? "login" : "forgot")}
-                className={cn(
-                  "rounded-full border border-white/20 px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.3em] transition",
-                  mode === "forgot" ? "bg-white/20 text-slate-900" : "text-white"
-                )}
-                aria-pressed={mode === "forgot"}
-              >
-                Mot de passe oublié
-              </button>
+              {mode === "forgot" && (
+                <button
+                  type="button"
+                  onClick={() => changeMode("login")}
+                  className="rounded-full border border-white/15 bg-white/10 px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-white/80 transition hover:text-white"
+                >
+                  Retour connexion
+                </button>
+              )}
             </div>
           </div>
 
@@ -344,7 +342,7 @@ const Auth = () => {
                   <button
                     type="button"
                     onClick={() => changeMode("forgot")}
-                    className="mt-3 text-[0.7rem] font-semibold uppercase tracking-[0.3em] text-cyan-200/80 transition hover:text-cyan-100"
+                    className="mt-3 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-slate-200/70 transition hover:text-white"
                   >
                     Mot de passe oublié ?
                   </button>
@@ -357,23 +355,6 @@ const Auth = () => {
                 </p>
               </div>
             )}
-            <div>
-              <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Mot de passe</label>
-              <input
-                type="password"
-                className="mt-2 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
-                value={form.password}
-                onChange={(event) => setForm((prev) => ({ ...prev, password: event.target.value }))}
-                placeholder={mode === "register" ? "Créer un mot de passe sécurisé" : "Votre mot de passe"}
-                required
-                minLength={8}
-              />
-              {mode === "register" && (
-                <p className="mt-2 text-[0.7rem] text-slate-300/70">
-                  Au moins 8 caractères, une majuscule et un chiffre pour sécuriser votre espace client.
-                </p>
-              )}
-            </div>
           </div>
 
           {error && (

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,5 +1,4 @@
-import { FormEvent, useMemo, useState } from "react";
-import { FormEvent, useMemo, useState, useCallback, useEffect } from "react";
+import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { useStudio } from "@/context/StudioContext";
 import type { QuoteRequest } from "@/context/StudioContext";
@@ -36,342 +35,35 @@ const quoteStatusCopy: Record<QuoteRequest["status"], { label: string; tone: str
   },
 };
 
-const Dashboard = () => {
-  const { user, quoteRequests, portfolioItems, chats } = useStudio();
-  const [isUnlocked, setIsUnlocked] = useState(false);
-  const [activeNavigation, setActiveNavigation] = useState("Dashboard");
-  const [credentials, setCredentials] = useState({
-    email: user?.email ?? "",
-    password: "",
-  });
-
-  const myQuotes = useMemo(() => {
-    if (!user) return [] as QuoteRequest[];
-    return quoteRequests
-      .filter((quote) => quote.clientId === user.id)
-      .slice()
-      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
-  }, [quoteRequests, user]);
-
-  const lastMessages = useMemo(() => {
-    const userQuoteIds = new Set(myQuotes.map((quote) => quote.id));
-    return chats
-      .filter((thread) => userQuoteIds.has(thread.quoteId))
-      .map((thread) => ({
-        quoteId: thread.quoteId,
-        projectName: thread.projectName,
-        last: thread.messages.slice().sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())[0],
-      }))
-      .filter((thread) => Boolean(thread.last))
-      .slice(0, 3);
-  }, [chats, myQuotes]);
-
-  const handleConnect = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    setIsUnlocked(true);
-  };
-
-  return (
-    <div className="min-h-screen bg-slate-950 text-white">
-      <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-12 px-6 pb-24 pt-20 lg:flex-row">
-        <div className="relative flex flex-1 flex-col justify-between rounded-[3rem] border border-white/10 bg-gradient-to-br from-[#1a2656] via-[#0c0e24] to-[#120420] p-10 shadow-[0_60px_120px_rgba(10,15,45,0.6)]">
-          <div>
-            <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-5 py-2 text-xs uppercase tracking-[0.4em] text-slate-200/70">
-              Studio VBG · Espace client
-            </span>
-            <h1 className="mt-10 text-4xl font-semibold tracking-tight text-white sm:text-5xl">
-              Accédez à l'espace client
-            </h1>
-            <p className="mt-6 max-w-lg text-base text-slate-200/80">
-              Créez votre compte ou connectez-vous pour consulter le tableau de bord, déposer un brief, suivre vos devis et échanger avec nos équipes.
-            </p>
-
-            <div className="mt-10 grid gap-6 sm:grid-cols-2">
-              <div className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
-                <p className="text-sm font-semibold uppercase tracking-[0.3em] text-cyan-200/80">Onboarding structuré</p>
-                <p className="mt-4 text-sm text-slate-200/80">
-                  Un formulaire clair pour rassembler les informations essentielles et aligner notre équipe sur votre projet.
-                </p>
-              </div>
-              <div className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
-                <p className="text-sm font-semibold uppercase tracking-[0.3em] text-sky-200/80">Sécurité maîtrisée</p>
-                <p className="mt-4 text-sm text-slate-200/80">
-                  Vos données sont hébergées en interne sur des environnements chiffrés et monitorés par nos producteurs.
-                </p>
-              </div>
-            </div>
-          </div>
-
-          <div className="mt-12 flex flex-wrap items-center gap-4 text-xs uppercase tracking-[0.3em] text-slate-200/60">
-            <span>Mode Vague</span>
-            <span className="h-px w-12 bg-slate-200/40" aria-hidden="true" />
-            <span>Palette Solstice</span>
-            <span className="h-px w-12 bg-slate-200/40" aria-hidden="true" />
-            <span>Typographie calibrée</span>
-          </div>
-        </div>
-
-        <div className="flex flex-1 items-stretch">
-          <div className="relative w-full overflow-hidden rounded-[3rem] border border-white/10 bg-gradient-to-b from-[#1a1f3a]/90 via-[#141226]/95 to-[#0b091b] p-10 shadow-[0_60px_120px_rgba(9,11,30,0.6)]">
-            <div className="flex flex-wrap items-center justify-between gap-4">
-              <div className="flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-[0.65rem] uppercase tracking-[0.35em] text-slate-100/70">
-                <span className="text-base">🌊</span> Mode Vague
-              </div>
-              <div className="flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-[0.65rem] uppercase tracking-[0.35em] text-slate-100/70">
-                <span className="text-base">🎨</span> Palette Solstice
-              </div>
-              <div className="flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-[0.65rem] uppercase tracking-[0.35em] text-slate-100/70">
-                <span className="text-base">🔐</span> Mot de passe oublié
-              </div>
-            </div>
-
-            {!isUnlocked ? (
-              <form className="mt-10 space-y-6" onSubmit={handleConnect}>
-                <div className="grid grid-cols-2 gap-2 rounded-full border border-white/10 bg-white/5 p-1 text-sm uppercase tracking-[0.35em] text-slate-100/70">
-                  <button
-                    type="button"
-                    className="rounded-full bg-white/10 px-6 py-3 font-semibold text-white shadow-[0_12px_30px_rgba(45,150,255,0.25)]"
-                  >
-                    Connexion
-                  </button>
-                  <button type="button" className="rounded-full px-6 py-3 text-slate-200/60">
-                    Créer un compte
-                  </button>
-                </div>
-
-                <div className="space-y-4">
-                  <div className="space-y-2">
-                    <label className="text-xs uppercase tracking-[0.35em] text-slate-200/70">Email</label>
-                    <input
-                      type="email"
-                      value={credentials.email}
-                      onChange={(event) => setCredentials((prev) => ({ ...prev, email: event.target.value }))}
-                      className="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white placeholder:text-slate-400 focus:border-cyan-300 focus:outline-none"
-                      placeholder="vous@studio2025.com"
-                      required
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <label className="text-xs uppercase tracking-[0.35em] text-slate-200/70">Mot de passe</label>
-                    <input
-                      type="password"
-                      value={credentials.password}
-                      onChange={(event) => setCredentials((prev) => ({ ...prev, password: event.target.value }))}
-                      className="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white placeholder:text-slate-400 focus:border-cyan-300 focus:outline-none"
-                      placeholder="Au moins 8 caractères"
-                      required
-                      minLength={8}
-                    />
-                    <div className="flex items-center justify-between text-[0.7rem] text-slate-300/70">
-                      <span>Minimum 8 caractères</span>
-                      <button type="button" className="font-semibold uppercase tracking-[0.3em] text-cyan-200/80 transition hover:text-cyan-100">
-                        Mot de passe oublié ?
-                      </button>
-                    </div>
-                  </div>
-                </div>
-
-                <button
-                  type="submit"
-                  className="group relative w-full overflow-hidden rounded-full border border-cyan-200/40 bg-cyan-500/20 px-6 py-3 text-sm font-bold uppercase tracking-[0.35em] text-white"
-                >
-                  <span className="relative z-10">Connexion</span>
-                  <span className="absolute inset-0 translate-x-[-120%] bg-gradient-to-r from-cyan-400 via-sky-300 to-fuchsia-400 transition-transform duration-700 group-hover:translate-x-0" />
-                </button>
-              </form>
-            ) : (
-              <div className="mt-10 space-y-8">
-                <div>
-                  <p className="text-xs uppercase tracking-[0.35em] text-slate-200/70">Bienvenue</p>
-                  <h2 className="mt-3 text-2xl font-semibold text-white">
-                    {user?.name ?? "Client Studio"}, voici votre cockpit projet.
-                  </h2>
-                  <p className="mt-2 text-sm text-slate-200/80">
-                    Visualisez vos devis, derniers échanges et accédez aux ressources clés de Studio VBG.
-                  </p>
-                </div>
-
-                <div className="grid gap-6 lg:grid-cols-2">
-                  <div className="rounded-3xl border border-white/10 bg-white/5 p-6">
-                    <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/80">Devis en cours</p>
-                    <ul className="mt-4 space-y-4">
-                      {myQuotes.length === 0 && (
-                        <li className="text-sm text-slate-200/70">Aucun devis en cours pour le moment.</li>
-                      )}
-                      {myQuotes.slice(0, 3).map((quote) => {
-                        const statusStyle = quoteStatusCopy[quote.status];
-                        return (
-                          <li key={quote.id} className="rounded-2xl border border-white/10 bg-[#0f1327]/80 p-4">
-                            <div className="flex items-center justify-between gap-4">
-                              <div>
-                                <p className="text-sm font-semibold text-white">{quote.projectName}</p>
-                                <p className="text-[0.7rem] uppercase tracking-[0.25em] text-slate-300/70">{quote.clientName}</p>
-                              </div>
-                              <span className={`rounded-full border px-3 py-1 text-[0.65rem] uppercase tracking-[0.3em] ${statusStyle.tone} ${statusStyle.border}`}>
-                                {statusStyle.label}
-                              </span>
-                            </div>
-                            <p className="mt-3 text-xs text-slate-200/70">Budget : {quote.budgetRange} · Deadline : {quote.deadline || "À définir"}</p>
-                          </li>
-                        );
-                      })}
-                    </ul>
-                  </div>
-
-                  <div className="rounded-3xl border border-white/10 bg-white/5 p-6">
-                    <p className="text-xs uppercase tracking-[0.3em] text-sky-200/80">Navigation rapide</p>
-                    <div className="mt-4 space-y-3">
-                      {quickNavigation.map((item) => {
-                        const isActive = item.label === activeNavigation;
-                        return (
-                          <Link
-                            key={item.label}
-                            to={item.to}
-                            onMouseEnter={() => setActiveNavigation(item.label)}
-                            className={`flex items-center justify-between gap-4 rounded-2xl border px-4 py-3 text-left transition ${
-                              isActive
-                                ? "border-cyan-300/60 bg-cyan-500/10 text-white shadow-[0_12px_40px_rgba(45,150,255,0.25)]"
-                                : "border-white/10 text-slate-200/80 hover:border-cyan-200/40 hover:bg-white/10"
-                            }`}
-                          >
-                            <div>
-                              <p className="text-sm font-semibold uppercase tracking-[0.25em]">{item.label}</p>
-                              <p className="text-xs text-slate-300/70">{item.description}</p>
-                            </div>
-                            <span className="text-lg">{item.icon}</span>
-                          </Link>
-                        );
-                      })}
-                    </div>
-                  </div>
-                </div>
-
-                <div className="rounded-3xl border border-white/10 bg-white/5 p-6">
-                  <p className="text-xs uppercase tracking-[0.3em] text-fuchsia-200/80">Derniers échanges</p>
-                  <ul className="mt-4 space-y-4">
-                    {lastMessages.length === 0 && (
-                      <li className="text-sm text-slate-200/70">Aucun échange récent. Lancez la conversation depuis votre chat projet.</li>
-                    )}
-                    {lastMessages.map((thread) => (
-                      <li key={thread.quoteId} className="rounded-2xl border border-white/10 bg-[#0f1327]/80 p-4">
-                        <p className="text-sm font-semibold text-white">{thread.projectName}</p>
-                        <p className="mt-2 text-xs text-slate-200/70">
-                          {thread.last?.from === "studio" ? "Studio VBG" : user?.name ?? "Vous"} · {thread.last?.content}
-                        </p>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-
-                <div className="rounded-3xl border border-white/10 bg-white/5 p-6">
-                  <p className="text-xs uppercase tracking-[0.3em] text-emerald-200/80">Projets en vitrine</p>
-                  <div className="mt-4 grid gap-4 sm:grid-cols-2">
-                    {portfolioItems.slice(0, 2).map((item) => (
-                      <div key={item.id} className="rounded-2xl border border-white/10 bg-[#0f1327]/80 p-4">
-                        <p className="text-sm font-semibold text-white">{item.title}</p>
-                        <p className="mt-1 text-xs text-slate-200/70">{item.category} · {item.year}</p>
-                        <p className="mt-2 text-xs text-slate-300/70">{item.tagline}</p>
-                      </div>
-                    ))}
-                    {portfolioItems.length === 0 && (
-                      <p className="text-sm text-slate-200/70">Aucun projet publié pour le moment.</p>
-                    )}
-                  </div>
-                </div>
-              </div>
-            )}
-          </div>
-        </div>
-
 const ADMIN_EMAIL = "volberg.thomas@gmail.com";
 
-type QuoteStatus = QuoteRequest["status"];
-type QuoteStep = Extract<QuoteStatus, "nouveau" | "en revue" | "validé">;
-
-const STATUS_STEPS: Array<{ key: QuoteStep; title: string; description: string }> = [
+const membershipOptions = [
   {
-    key: "nouveau",
-    title: "Brief reçu",
-    description: "Votre demande est horodatée, l'équipe la priorise dans la file Studio VBG.",
+    value: "Hyperdrive",
+    label: "Hyperdrive",
+    description: "Production intensive pour contenus à cadence élevée.",
   },
   {
-    key: "en revue",
-    title: "Analyse créative",
-    description: "Nous alignons budget, équipe et pipeline IA avant de vous soumettre la proposition.",
+    value: "Continuum",
+    label: "Continuum",
+    description: "Accompagnement annuel avec équipe dédiée.",
   },
   {
-    key: "validé",
-    title: "Kick-off",
-    description: "Le devis est signé, la salle de chat projet et la préproduction s'activent.",
+    value: "Impulse",
+    label: "Impulse",
+    description: "Starter agile pour lancer votre présence vidéo.",
   },
-];
+] as const;
 
-const STATUS_BADGES: Record<QuoteStatus, string> = {
-  nouveau: "border-cyan-200/40 bg-cyan-500/10 text-cyan-100",
-  "en revue": "border-sky-200/40 bg-sky-500/10 text-sky-100",
-  validé: "border-emerald-200/40 bg-emerald-500/10 text-emerald-100",
-  refusé: "border-rose-300/50 bg-rose-500/10 text-rose-100",
+type MembershipValue = (typeof membershipOptions)[number]["value"];
+
+type AccountDraft = {
+  name: string;
+  company: string;
+  industry: string;
+  membership: MembershipValue;
+  lastProject: string;
 };
-
-const STATUS_LABELS: Record<QuoteStatus, string> = {
-  nouveau: "Nouveau",
-  "en revue": "En revue",
-  validé: "Validé",
-  refusé: "Réorienté",
-};
-
-const STATUS_MESSAGES: Record<QuoteStatus, string> = {
-  nouveau: "Brief reçu, notre IA prépare un storyboard exploratoire.",
-  "en revue": "Nos producers challenge le brief avec budget, planning et outils IA.",
-  validé: "Proposition acceptée : préparation des tournages, booking équipe et lancement chat.",
-  refusé: "Nous vous recontactons pour ajuster l'approche ou proposer une alternative.",
-};
-
-const formatDate = (value: string) => {
-  if (!value) return "À définir";
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return value;
-  return new Intl.DateTimeFormat("fr-FR", { day: "2-digit", month: "long", year: "numeric" }).format(date);
-};
-
-const formatTime = (value: string) => {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return "";
-  return new Intl.DateTimeFormat("fr-FR", { hour: "2-digit", minute: "2-digit" }).format(date);
-};
-
-const getTimeValue = (value: string) => {
-  const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? 0 : date.getTime();
-};
-
-type PortfolioDraft = {
-  title: string;
-  tagline: string;
-  category: string;
-  year: number;
-  duration: string;
-  description: string;
-  thumbnail: string;
-  videoUrl: string;
-  aiTools: string;
-  deliverables: string;
-  socialStack: string;
-};
-
-const getDefaultProject = (categories: string[]): PortfolioDraft => ({
-  title: "",
-  tagline: "",
-  category: categories[0] ?? "Entreprise",
-  year: new Date().getFullYear(),
-  duration: "00:45",
-  description: "",
-  thumbnail: "",
-  videoUrl: "",
-  aiTools: "",
-  deliverables: "",
-  socialStack: "",
-});
 
 const Dashboard = () => {
   const {
@@ -389,6 +81,10 @@ const Dashboard = () => {
     updatePricingTier,
     advanceQuoteStatus,
     appendChatMessage,
+    updateAccount,
+    visualMode,
+    cycleVisualMode,
+    palette,
   } = useStudio();
 
   const isAdmin = user?.email === ADMIN_EMAIL;
@@ -420,6 +116,17 @@ const Dashboard = () => {
   const [isImportingMetadata, setIsImportingMetadata] = useState(false);
   const [metadataError, setMetadataError] = useState<string | null>(null);
   const [editDraft, setEditDraft] = useState<(PortfolioDraft & { id: string }) | null>(null);
+  const [accountDraft, setAccountDraft] = useState<AccountDraft>(() => ({
+    name: user?.name ?? "",
+    company: user?.company ?? "",
+    industry: user?.industry ?? "",
+    membership: (user?.membership ?? "Hyperdrive") as MembershipValue,
+    lastProject: user?.lastProject ?? "",
+  }));
+  const [isSavingAccount, setIsSavingAccount] = useState(false);
+  const [accountFeedback, setAccountFeedback] = useState<
+    { type: "success" | "error"; message: string }
+  | null>(null);
 
   const activeChat = useMemo(() => chats.find((chat) => chat.quoteId === selectedChatId), [chats, selectedChatId]);
 
@@ -445,6 +152,18 @@ const Dashboard = () => {
     });
   }, [myChats]);
 
+  useEffect(() => {
+    if (!user) return;
+    setAccountDraft({
+      name: user.name,
+      company: user.company,
+      industry: user.industry,
+      membership: user.membership as MembershipValue,
+      lastProject: user.lastProject ?? "",
+    });
+    setAccountFeedback(null);
+  }, [user]);
+
   const clientActiveChat = useMemo(
     () => myChats.find((thread) => thread.quoteId === clientSelectedChatId) ?? null,
     [myChats, clientSelectedChatId],
@@ -454,6 +173,45 @@ const Dashboard = () => {
     () => myQuotes.find((quote) => quote.id === clientSelectedQuoteId) ?? null,
     [clientSelectedQuoteId, myQuotes],
   );
+
+  const handleAccountSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!user) return;
+
+    setIsSavingAccount(true);
+    setAccountFeedback(null);
+
+    const response = await updateAccount({
+      name: accountDraft.name.trim(),
+      company: accountDraft.company.trim(),
+      industry: accountDraft.industry.trim(),
+      membership: accountDraft.membership,
+      lastProject:
+        accountDraft.lastProject.trim().length > 0 ? accountDraft.lastProject.trim() : null,
+    });
+
+    setIsSavingAccount(false);
+    setAccountFeedback({
+      type: response.success ? "success" : "error",
+      message:
+        response.message ??
+        (response.success
+          ? "Profil mis à jour."
+          : "La mise à jour du profil a échoué. Réessayez dans un instant."),
+    });
+  };
+
+  const handleAccountReset = () => {
+    if (!user) return;
+    setAccountDraft({
+      name: user.name,
+      company: user.company,
+      industry: user.industry,
+      membership: user.membership as MembershipValue,
+      lastProject: user.lastProject ?? "",
+    });
+    setAccountFeedback(null);
+  };
 
   const handleClientSendMessage = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -568,6 +326,18 @@ const Dashboard = () => {
                 Suivez vos demandes de devis, consultez les étapes clés et échangez avec le producteur dédié.
               </p>
               <div className="flex flex-wrap gap-3">
+                <button
+                  type="button"
+                  onClick={cycleVisualMode}
+                  className="group relative flex items-center gap-3 rounded-full border border-cyan-200/40 visual-accent-border bg-white/10 px-5 py-3 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-cyan-100 visual-accent-text shadow-[0_10px_30px_rgba(8,145,178,0.25)] visual-accent-shadow transition hover:scale-105"
+                >
+                  <span
+                    className="h-2.5 w-2.5 rounded-full shadow-[0_0_12px_rgba(255,255,255,0.35)]"
+                    style={{ background: `hsl(${palette.accent})` }}
+                  />
+                  {visualMode === "nebula" ? "Palette Solstice" : "Palette Nébula"}
+                  <span className="pointer-events-none absolute inset-0 -z-10 translate-x-[-120%] rounded-full bg-gradient-to-r from-cyan-400/40 via-transparent to-fuchsia-400/40 transition-transform duration-700 group-hover:translate-x-0" />
+                </button>
                 <Link
                   to="/quote"
                   className="rounded-full border border-cyan-200/40 visual-accent-border bg-cyan-500/20 visual-accent-bg px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white"
@@ -606,6 +376,148 @@ const Dashboard = () => {
           </header>
 
           <section className="mt-16 space-y-12">
+            <div className="rounded-[3rem] border border-white/10 bg-white/10 p-10 shadow-[0_20px_90px_rgba(56,189,248,0.12)] visual-accent-veil">
+              <form className="space-y-8" onSubmit={handleAccountSubmit}>
+                <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                  <div className="space-y-3">
+                    <p className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Profil client</p>
+                    <h2 className="text-3xl font-bold text-white">Vos informations</h2>
+                    <p className="text-sm text-slate-200/70">
+                      Complétez votre identité et vos préférences pour que l'IA prépare des recommandations sur-mesure.
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap gap-2 md:justify-end">
+                    <button
+                      type="button"
+                      onClick={handleAccountReset}
+                      className="rounded-full border border-white/15 bg-white/5 px-5 py-2 text-[0.7rem] font-semibold uppercase tracking-[0.3em] text-slate-200/80 transition hover:text-white"
+                    >
+                      Réinitialiser
+                    </button>
+                    <button
+                      type="submit"
+                      disabled={isSavingAccount}
+                      className={`rounded-full border px-5 py-2 text-[0.7rem] font-semibold uppercase tracking-[0.3em] transition ${
+                        isSavingAccount
+                          ? "cursor-not-allowed border-cyan-200/30 bg-cyan-500/10 text-white/70"
+                          : "border-cyan-200/40 bg-cyan-500/20 text-white hover:scale-[1.02]"
+                      }`}
+                    >
+                      {isSavingAccount ? "Enregistrement..." : "Enregistrer"}
+                    </button>
+                  </div>
+                </div>
+
+                {accountFeedback && (
+                  <p
+                    className={`rounded-2xl border px-4 py-3 text-sm ${
+                      accountFeedback.type === "success"
+                        ? "border-emerald-400/40 bg-emerald-500/10 text-emerald-100"
+                        : "border-rose-400/40 bg-rose-500/10 text-rose-100"
+                    }`}
+                  >
+                    {accountFeedback.message}
+                  </p>
+                )}
+
+                <div className="grid gap-6 md:grid-cols-2">
+                  <div>
+                    <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Nom complet</label>
+                    <input
+                      className="mt-2 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                      value={accountDraft.name}
+                      onChange={(event) => {
+                        const value = event.target.value;
+                        setAccountDraft((prev) => ({ ...prev, name: value }));
+                        setAccountFeedback(null);
+                      }}
+                      placeholder="Nom et prénom"
+                      required
+                    />
+                  </div>
+                  <div>
+                    <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Entreprise</label>
+                    <input
+                      className="mt-2 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                      value={accountDraft.company}
+                      onChange={(event) => {
+                        const value = event.target.value;
+                        setAccountDraft((prev) => ({ ...prev, company: value }));
+                        setAccountFeedback(null);
+                      }}
+                      placeholder="Votre structure ou collectif"
+                    />
+                  </div>
+                  <div>
+                    <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Secteur</label>
+                    <input
+                      className="mt-2 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                      value={accountDraft.industry}
+                      onChange={(event) => {
+                        const value = event.target.value;
+                        setAccountDraft((prev) => ({ ...prev, industry: value }));
+                        setAccountFeedback(null);
+                      }}
+                      placeholder="Ex. Tech, Luxe, Événementiel..."
+                    />
+                  </div>
+                  <div className="hidden md:block" />
+                </div>
+
+                <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
+                  <div>
+                    <p className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Formule active</p>
+                    <div className="mt-3 grid gap-3 sm:grid-cols-3">
+                      {membershipOptions.map((option) => {
+                        const isActive = accountDraft.membership === option.value;
+                        return (
+                          <button
+                            key={option.value}
+                            type="button"
+                            onClick={() => {
+                              setAccountDraft((prev) => ({ ...prev, membership: option.value }));
+                              setAccountFeedback(null);
+                            }}
+                            className={`rounded-2xl border px-4 py-3 text-left transition ${
+                              isActive
+                                ? "border-cyan-300/80 bg-cyan-500/20 text-white shadow-[0_10px_35px_rgba(56,189,248,0.25)]"
+                                : "border-white/10 bg-white/5 text-slate-200/80 hover:border-cyan-200/40 hover:bg-white/10"
+                            }`}
+                            aria-pressed={isActive}
+                          >
+                            <span className="text-sm font-semibold uppercase tracking-[0.25em] text-cyan-100/80 visual-accent-text-strong">
+                              {option.label}
+                            </span>
+                            <p className="mt-2 text-xs text-slate-200/80">{option.description}</p>
+                          </button>
+                        );
+                      })}
+                    </div>
+                    <p className="mt-2 text-[0.7rem] text-slate-300/70">
+                      Ajustable à tout moment selon l'intensité de vos campagnes.
+                    </p>
+                  </div>
+                  <div>
+                    <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Dernier projet marquant</label>
+                    <textarea
+                      rows={4}
+                      className="mt-2 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
+                      value={accountDraft.lastProject}
+                      onChange={(event) => {
+                        const value = event.target.value;
+                        setAccountDraft((prev) => ({ ...prev, lastProject: value }));
+                        setAccountFeedback(null);
+                      }}
+                      placeholder="Partagez un tournage, un lancement ou un succès que vous souhaitez prolonger."
+                    />
+                    <p className="mt-2 text-[0.7rem] text-slate-300/70">
+                      Ces éléments nourrissent les prompts IA et facilitent la préparation des briefs.
+                    </p>
+                  </div>
+                </div>
+              </form>
+            </div>
+
             {hasQuotes ? (
               <div className="rounded-[3rem] border border-white/10 bg-white/10 p-10 shadow-[0_20px_100px_rgba(56,189,248,0.18)] visual-accent-veil">
                 <div className="flex flex-col gap-6">
@@ -941,9 +853,23 @@ const Dashboard = () => {
                 Gérez vos projets, suivez vos devis, ajustez vos tarifs et discutez avec nos équipes. Tout est synchronisé avec notre pipeline IA.
               </p>
             </div>
-            <div className="rounded-[2.5rem] border border-white/10 bg-white/10 p-8 text-sm text-slate-200/80">
-              <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Stat instantané</p>
-              <p className="mt-3 text-white">{portfolioItems.length} projets en cours · {quoteRequests.length} devis · {contactRequests.length} demandes rapides</p>
+            <div className="flex flex-col items-stretch gap-4 lg:items-end">
+              <button
+                type="button"
+                onClick={cycleVisualMode}
+                className="group relative flex items-center gap-3 self-end rounded-full border border-cyan-200/40 visual-accent-border bg-white/10 px-5 py-3 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-cyan-100 visual-accent-text shadow-[0_10px_30px_rgba(8,145,178,0.25)] visual-accent-shadow transition hover:scale-105"
+              >
+                <span
+                  className="h-2.5 w-2.5 rounded-full shadow-[0_0_12px_rgba(255,255,255,0.35)]"
+                  style={{ background: `hsl(${palette.accent})` }}
+                />
+                {visualMode === "nebula" ? "Palette Solstice" : "Palette Nébula"}
+                <span className="pointer-events-none absolute inset-0 -z-10 translate-x-[-120%] rounded-full bg-gradient-to-r from-cyan-400/40 via-transparent to-fuchsia-400/40 transition-transform duration-700 group-hover:translate-x-0" />
+              </button>
+              <div className="rounded-[2.5rem] border border-white/10 bg-white/10 p-8 text-sm text-slate-200/80">
+                <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Stat instantané</p>
+                <p className="mt-3 text-white">{portfolioItems.length} projets en cours · {quoteRequests.length} devis · {contactRequests.length} demandes rapides</p>
+              </div>
             </div>
           </div>
         </header>


### PR DESCRIPTION
## Summary
- remove the palette toggle from the global wave menu so it no longer appears on public/auth pages
- add the visual palette switcher to the client dashboard header alongside the account actions
- surface the same toggle in the admin dashboard view to keep theme switching available after sign-in

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d58e16190883288a0ff760f71bb26a