### PR TITLE
feat: add hero ribbon reacting to scroll

### DIFF
--- a/src/components/HeroRibbon.tsx
+++ b/src/components/HeroRibbon.tsx
@@ -1,0 +1,29 @@
+import { Link } from "react-router-dom";
+import { cn } from "@/lib/utils";
+
+type HeroRibbonProps = {
+  visible?: boolean;
+};
+
+export const HeroRibbon = ({ visible = true }: HeroRibbonProps) => {
+  return (
+    <div className={cn("hero-ribbon", !visible && "hidden")}> 
+      <div className="hero-ribbon__content">
+        <span className="hero-ribbon__pulse" aria-hidden="true" />
+        <div className="hero-ribbon__text">
+          <p className="hero-ribbon__headline">
+            Studio VBG synchronise vos lancements vidéo IA avec vos équipes marketing.
+          </p>
+          <p className="hero-ribbon__subheadline">
+            Planning prioritaire, scripts sur-mesure, rendu premium en 48h.
+          </p>
+        </div>
+        <Link to="/quote" className="hero-ribbon__cta">
+          Réserver un audit
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default HeroRibbon;

--- a/src/index.css
+++ b/src/index.css
@@ -101,6 +101,123 @@ All colors MUST be HSL.
   }
 }
 
+.hero-ribbon {
+  position: sticky;
+  top: 0.75rem;
+  z-index: 40;
+  display: flex;
+  justify-content: center;
+  padding: 0 1.5rem;
+  transition: transform 0.45s ease, opacity 0.45s ease;
+  transform: translateY(0);
+  opacity: 1;
+  pointer-events: none;
+}
+
+.hero-ribbon.hidden {
+  transform: translateY(-120%);
+  opacity: 0;
+}
+
+.hero-ribbon__content {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  width: min(68rem, 100%);
+  border-radius: 999px;
+  border: 1px solid hsla(var(--visual-border) / 0.25);
+  background: linear-gradient(
+    120deg,
+    hsla(var(--visual-accent) / 0.22),
+    hsla(var(--visual-secondary) / 0.2)
+  );
+  box-shadow: 0 20px 60px hsla(var(--visual-accent) / 0.18);
+  padding: 0.85rem 1.5rem;
+  backdrop-filter: blur(20px);
+  pointer-events: auto;
+}
+
+.hero-ribbon__pulse {
+  width: 0.95rem;
+  height: 0.95rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, hsl(var(--visual-accent)), hsl(var(--visual-secondary)));
+  box-shadow: 0 0 0 0 hsla(var(--visual-accent) / 0.6);
+  animation: heroRibbonPulse 1.6s ease-in-out infinite;
+  flex-shrink: 0;
+}
+
+.hero-ribbon__text {
+  display: grid;
+  gap: 0.15rem;
+  flex: 1;
+}
+
+.hero-ribbon__headline {
+  font-size: clamp(0.95rem, 2vw, 1.125rem);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: hsl(var(--visual-accent-foreground));
+}
+
+.hero-ribbon__subheadline {
+  font-size: clamp(0.75rem, 1.6vw, 0.9rem);
+  color: hsla(var(--visual-accent-foreground) / 0.75);
+}
+
+.hero-ribbon__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.65rem 1.35rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.35em;
+  font-weight: 700;
+  background: hsla(var(--visual-accent) / 0.3);
+  color: hsl(var(--visual-accent-foreground));
+  border: 1px solid hsla(var(--visual-border) / 0.35);
+  transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+  white-space: nowrap;
+}
+
+.hero-ribbon__cta:hover {
+  transform: translateY(-1px);
+  background: hsla(var(--visual-secondary) / 0.4);
+  box-shadow: 0 15px 35px hsla(var(--visual-secondary) / 0.28);
+}
+
+@keyframes heroRibbonPulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 hsla(var(--visual-accent) / 0.6);
+    opacity: 1;
+  }
+  50% {
+    box-shadow: 0 0 0 12px hsla(var(--visual-accent) / 0);
+    opacity: 0.5;
+  }
+}
+
+@media (max-width: 768px) {
+  .hero-ribbon {
+    top: 0.5rem;
+    padding: 0 1rem;
+  }
+
+  .hero-ribbon__content {
+    flex-direction: column;
+    border-radius: 2rem;
+    text-align: center;
+    padding: 1rem 1.25rem;
+  }
+
+  .hero-ribbon__cta {
+    width: 100%;
+  }
+}
+
 @layer base {
   * {
     @apply border-border;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import { useEffect, useState } from "react";
+import HeroRibbon from "@/components/HeroRibbon";
 import { useStudio } from "@/context/StudioContext";
 import { servicesData } from "@/lib/services";
 import { cn } from "@/lib/utils";
@@ -27,6 +28,7 @@ const Index = () => {
   const [contactSent, setContactSent] = useState(false);
   const [heroImageLoaded, setHeroImageLoaded] = useState(false);
   const [heroImageError, setHeroImageError] = useState(false);
+  const [isRibbonVisible, setIsRibbonVisible] = useState(true);
   const [form, setForm] = useState({
     name: "",
     email: "",
@@ -37,12 +39,44 @@ const Index = () => {
   const heroProject = portfolioItems[0];
 
   useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    let ticking = false;
+
+    const updateVisibility = () => {
+      setIsRibbonVisible(window.scrollY <= 40);
+    };
+
+    const handleScroll = () => {
+      if (ticking) {
+        return;
+      }
+
+      ticking = true;
+      window.requestAnimationFrame(() => {
+        updateVisibility();
+        ticking = false;
+      });
+    };
+
+    updateVisibility();
+    window.addEventListener("scroll", handleScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
+  useEffect(() => {
     setHeroImageLoaded(false);
     setHeroImageError(false);
   }, [heroProject?.thumbnail]);
 
   return (
     <div className="relative min-h-screen overflow-x-hidden bg-slate-950 text-white">
+      <HeroRibbon visible={isRibbonVisible} />
       <div
         className="pointer-events-none absolute inset-0"
         style={{


### PR DESCRIPTION
## Summary
- add a reusable `HeroRibbon` component for the hero banner callout
- toggle the ribbon visibility on the home page based on scroll position using `requestAnimationFrame`
- craft CSS animations and responsive styling so the ribbon slides/fades away on scroll without blocking content

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5c1bedd9883288952d93fbc57a1f7