### PR TITLE
Improve portfolio filter bar responsiveness

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -391,26 +391,47 @@ All colors MUST be HSL.
     animation-play-state: running;
   }
 
+  .portfolio-filter-scroll-wrapper {
+    position: relative;
+    -webkit-overflow-scrolling: touch;
+    --portfolio-filter-fade: clamp(12px, 4vw, 52px);
+    -webkit-mask-image: linear-gradient(
+      to right,
+      transparent 0,
+      #000 var(--portfolio-filter-fade),
+      #000 calc(100% - var(--portfolio-filter-fade)),
+      transparent 100%
+    );
+    mask-image: linear-gradient(
+      to right,
+      transparent 0,
+      #000 var(--portfolio-filter-fade),
+      #000 calc(100% - var(--portfolio-filter-fade)),
+      transparent 100%
+    );
+  }
+
   .portfolio-filter-trigger {
     position: relative;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: 0.45rem 0.25rem;
+    padding: 0.5rem 0.85rem;
     border: none;
     border-radius: 9999px;
     background: transparent;
     color: hsla(0, 0%, 100%, 0.55);
     transition: color 0.4s ease, transform 0.4s ease;
     cursor: pointer;
+    box-shadow: inset 0 0 0 1px hsla(var(--visual-border) / 0.12);
   }
 
   .portfolio-filter-trigger::after {
     content: "";
     position: absolute;
-    left: 8%;
-    right: 8%;
-    bottom: -0.45rem;
+    left: 20%;
+    right: 20%;
+    bottom: -0.3rem;
     height: 2px;
     border-radius: 9999px;
     background: linear-gradient(90deg, hsla(var(--visual-accent) / 0.5), hsla(var(--visual-secondary) / 0.35));
@@ -439,11 +460,11 @@ All colors MUST be HSL.
   }
 
   .portfolio-filter-active {
-    padding: 0.65rem 1.55rem;
+    padding: 0.6rem 1.2rem;
     background: linear-gradient(120deg, hsla(var(--visual-accent) / 0.45), hsla(var(--visual-secondary) / 0.35), hsla(var(--visual-tertiary) / 0.4));
     color: white;
-    box-shadow: 0 20px 60px hsla(var(--visual-accent) / 0.28);
-    border: 1px solid hsla(var(--visual-border) / 0.35);
+    box-shadow: 0 20px 48px hsla(var(--visual-accent) / 0.24);
+    border: 1px solid hsla(var(--visual-border) / 0.32);
     transform: translateY(-2px);
   }
 

--- a/src/pages/Portfolio.tsx
+++ b/src/pages/Portfolio.tsx
@@ -164,24 +164,26 @@ const Portfolio = () => {
                 livrables et la stratégie IA correspondante.
               </p>
             </div>
-            <nav className="flex flex-wrap items-center gap-3 text-[11px] font-semibold uppercase tracking-[0.35em]">
-              {categories.map((category) => {
-                const isActive = filter === category;
-                return (
-                  <button
-                    key={category}
-                    type="button"
-                    onClick={() => setFilter(category)}
-                    className={`portfolio-filter-trigger ${
-                      isActive ? "portfolio-filter-active" : "portfolio-filter-idle"
-                    }`}
-                    aria-pressed={isActive}
-                  >
-                    {category}
-                  </button>
-                );
-              })}
-            </nav>
+            <div className="portfolio-filter-scroll-wrapper overflow-x-auto whitespace-nowrap pb-2">
+              <nav className="flex w-max flex-nowrap items-center gap-3 text-[11px] font-semibold uppercase tracking-[0.35em]">
+                {categories.map((category) => {
+                  const isActive = filter === category;
+                  return (
+                    <button
+                      key={category}
+                      type="button"
+                      onClick={() => setFilter(category)}
+                      className={`portfolio-filter-trigger ${
+                        isActive ? "portfolio-filter-active" : "portfolio-filter-idle"
+                      }`}
+                      aria-pressed={isActive}
+                    >
+                      {category}
+                    </button>
+                  );
+                })}
+              </nav>
+            </div>
           </header>
 
           <div className="portfolio-gallery grid gap-6 sm:grid-cols-2 xl:grid-cols-4">


### PR DESCRIPTION
## Summary
- wrap the portfolio filter navigation in a horizontal scroll container to keep pills on one line
- tweak the filter button spacing and active styles to prevent overflow from pseudo-elements
- add a gradient mask to the scroll wrapper so horizontal scrolling remains legible on narrow screens

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5c1b7283c8328ab3571dc75c5974b