### PR TITLE
Add homepage filmstrip preview section

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -196,6 +196,232 @@ All colors MUST be HSL.
   box-shadow: 0 15px 50px hsla(var(--visual-secondary) / 0.28) !important;
 }
 
+.homepage-filmstrip {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: 1.75rem;
+  margin: -2.5rem auto 4rem;
+  max-width: 80rem;
+  padding: 2.25rem 2.75rem;
+  border-radius: 2.5rem;
+  border: 1px solid hsla(var(--visual-border) / 0.35);
+  background:
+    radial-gradient(circle at 12% 18%, hsla(var(--visual-secondary) / 0.2), transparent 55%),
+    linear-gradient(135deg, rgba(7, 12, 22, 0.9), rgba(15, 23, 42, 0.88) 55%, hsla(var(--visual-accent) / 0.16));
+  box-shadow: 0 35px 120px hsla(var(--visual-accent) / 0.2);
+  isolation: isolate;
+  backdrop-filter: blur(18px);
+}
+
+.homepage-filmstrip::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid hsla(var(--visual-border) / 0.22);
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+.filmstrip-track {
+  position: relative;
+  flex: 1 1 0%;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.25rem;
+  z-index: 1;
+}
+
+.filmstrip-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  padding: 1.15rem;
+  border-radius: 1.85rem;
+  border: 1px solid hsla(var(--visual-border) / 0.25);
+  background: linear-gradient(160deg, rgba(11, 18, 32, 0.92), rgba(15, 23, 42, 0.72));
+  color: inherit;
+  text-decoration: none;
+  box-shadow: 0 25px 80px hsla(var(--visual-accent) / 0.16);
+  overflow: hidden;
+  transition:
+    transform 0.55s cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 0.55s cubic-bezier(0.22, 1, 0.36, 1),
+    border-color 0.55s ease;
+}
+
+.filmstrip-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(140deg, hsla(var(--visual-accent) / 0.1), transparent 60%);
+  opacity: 0;
+  transition: opacity 0.55s ease;
+  pointer-events: none;
+}
+
+.filmstrip-card:hover {
+  transform: translateY(-6px);
+  border-color: hsla(var(--visual-border) / 0.5);
+  box-shadow: 0 40px 120px hsla(var(--visual-accent) / 0.26);
+}
+
+.filmstrip-card:hover::after {
+  opacity: 1;
+}
+
+.filmstrip-card-category {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.4rem 0.85rem;
+  border-radius: 9999px;
+  border: 1px solid hsla(var(--visual-border) / 0.4);
+  background: hsla(var(--visual-accent) / 0.18);
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: hsla(var(--visual-accent-foreground) / 0.88);
+}
+
+.filmstrip-card-thumb {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+  border-radius: 1.35rem;
+  border: 1px solid hsla(var(--visual-border) / 0.35);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.filmstrip-card-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.filmstrip-card-meta h3 {
+  font-size: 1.05rem;
+  font-weight: 700;
+  line-height: 1.3;
+  color: #fff;
+}
+
+.filmstrip-card-meta p {
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.filmstrip-card-arrow {
+  position: absolute;
+  right: 1.15rem;
+  bottom: 1.15rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 9999px;
+  border: 1px solid hsla(var(--visual-border) / 0.38);
+  background: hsla(var(--visual-secondary) / 0.32);
+  color: #fff;
+  font-size: 1.1rem;
+  transition:
+    transform 0.45s ease,
+    background 0.45s ease,
+    border-color 0.45s ease;
+}
+
+.filmstrip-card:hover .filmstrip-card-arrow {
+  transform: translate(2px, -2px) scale(1.05);
+  background: hsla(var(--visual-accent) / 0.42);
+  border-color: hsla(var(--visual-border) / 0.6);
+}
+
+.filmstrip-action {
+  position: relative;
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 12rem;
+  z-index: 1;
+}
+
+.filmstrip-action-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.9rem 1.6rem;
+  border-radius: 9999px;
+  border: 1px solid hsla(var(--visual-border) / 0.45);
+  background: linear-gradient(120deg, hsla(var(--visual-accent) / 0.32), hsla(var(--visual-secondary) / 0.32));
+  box-shadow: 0 18px 60px hsla(var(--visual-accent) / 0.28);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: #fff;
+  text-decoration: none;
+  transition: transform 0.4s ease, box-shadow 0.4s ease;
+}
+
+.filmstrip-action-link::after {
+  content: "➜";
+  font-size: 1rem;
+}
+
+.filmstrip-action-link:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 26px 90px hsla(var(--visual-accent) / 0.36);
+}
+
+@media (max-width: 1024px) {
+  .homepage-filmstrip {
+    margin-top: -1.5rem;
+    padding: 2rem 2.25rem;
+    gap: 1.5rem;
+  }
+
+  .filmstrip-card {
+    padding: 1rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .homepage-filmstrip {
+    flex-direction: column;
+    align-items: stretch;
+    padding: 1.75rem 1.75rem 2rem;
+  }
+
+  .filmstrip-action {
+    justify-content: flex-end;
+    width: 100%;
+  }
+}
+
+@media (max-width: 640px) {
+  .filmstrip-track {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 480px) {
+  .filmstrip-track {
+    grid-template-columns: 1fr;
+  }
+
+  .filmstrip-action {
+    justify-content: flex-start;
+  }
+}
+
 @keyframes auroraDrift {
   0% {
     transform: translate3d(-6%, -4%, 0) rotate(0deg) scale(1.02);

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -189,6 +189,38 @@ const Index = () => {
           </div>
         </header>
 
+        <section className="homepage-filmstrip" aria-label="Extraits du portfolio Studio VBG">
+          <div className="filmstrip-track">
+            {portfolioItems.slice(0, 4).map((project) => (
+              <Link
+                key={project.id}
+                to="/portfolio"
+                className="filmstrip-card"
+                aria-label={`Voir le projet ${project.title} dans le portfolio`}
+              >
+                <span className="filmstrip-card-category">{project.category}</span>
+                <img
+                  src={project.thumbnail}
+                  alt={`Aperçu du projet ${project.title}`}
+                  className="filmstrip-card-thumb"
+                />
+                <div className="filmstrip-card-meta">
+                  <h3>{project.title}</h3>
+                  <p>
+                    {project.duration} · {project.year}
+                  </p>
+                </div>
+                <span className="filmstrip-card-arrow" aria-hidden>↗</span>
+              </Link>
+            ))}
+          </div>
+          <div className="filmstrip-action">
+            <Link to="/portfolio" className="filmstrip-action-link">
+              Voir le portfolio
+            </Link>
+          </div>
+        </section>
+
         <section className="relative mx-auto max-w-6xl px-6 pb-24">
           <div
             className="absolute inset-0 -z-10 blur-3xl"


### PR DESCRIPTION
## Summary
- add a homepage filmstrip section highlighting four portfolio projects with accessible metadata and CTA
- style the new filmstrip, cards, and CTA button to match the dark ribbon art direction and handle responsive wrapping

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5c1a33284832891da34cb9b191d62