### PR TITLE
Adjust hero ribbon spacing below WaveMenu

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -53,6 +53,7 @@ All colors MUST be HSL.
     --visual-tertiary: 251 96% 72%;
     --visual-accent-foreground: 190 100% 92%;
     --visual-border: 188 86% 64%;
+    --wave-menu-height: 5.5rem;
   }
 
   .dark {
@@ -96,7 +97,7 @@ All colors MUST be HSL.
 
 .hero-ribbon {
   position: sticky;
-  top: 0.75rem;
+  top: calc(var(--wave-menu-height) + 0.75rem);
   z-index: 40;
   display: flex;
   justify-content: center;
@@ -195,7 +196,7 @@ All colors MUST be HSL.
 
 @media (max-width: 768px) {
   .hero-ribbon {
-    top: 0.5rem;
+    top: calc(var(--wave-menu-height) + 0.5rem);
     padding: 0 1rem;
   }
 


### PR DESCRIPTION
## Summary
- add a --wave-menu-height CSS custom property to share the WaveMenu pill height
- position the hero ribbon using the shared variable on desktop and mobile breakpoints so it clears the menu

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68d60bd0339c832890ea952cb5f166df