### PR TITLE
Refine videographer experience and add brand pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,8 @@ import Process from "./pages/Process";
 import QuoteBuilder from "./pages/QuoteBuilder";
 import Auth from "./pages/Auth";
 import Dashboard from "./pages/Dashboard";
+import About from "./pages/About";
+import Contact from "./pages/Contact";
 import { StudioProvider } from "./context/StudioContext";
 import { WaveMenu } from "./components/WaveMenu";
 import { ProtectedRoute } from "./components/ProtectedRoute";
@@ -33,8 +35,11 @@ const App = () => (
             <Route path="/services/:slug" element={<ServiceDetail />} />
             <Route path="/playground" element={<Playground />} />
             <Route path="/portfolio" element={<Portfolio />} />
+            <Route path="/realisations" element={<Portfolio />} />
             <Route path="/process" element={<Process />} />
             <Route path="/quote" element={<QuoteBuilder />} />
+            <Route path="/a-propos" element={<About />} />
+            <Route path="/contact" element={<Contact />} />
             <Route path="/auth" element={<Auth />} />
             <Route
               path="/dashboard"

--- a/src/components/HeroRibbon.tsx
+++ b/src/components/HeroRibbon.tsx
@@ -12,14 +12,14 @@ export const HeroRibbon = ({ visible = true }: HeroRibbonProps) => {
         <span className="hero-ribbon__pulse" aria-hidden="true" />
         <div className="hero-ribbon__text">
           <p className="hero-ribbon__headline">
-            Studio VBG synchronise vos lancements vidéo IA avec vos équipes marketing.
+            Alex VBG · vidéaste freelance nouvelle génération pour vos films 2025.
           </p>
           <p className="hero-ribbon__subheadline">
-            Planning prioritaire, scripts sur-mesure, rendu premium en 48h.
+            Studio mobile, IA créative et montage broadcast pour propulser vos histoires.
           </p>
         </div>
         <Link to="/quote" className="hero-ribbon__cta">
-          Réserver un audit
+          Bloquer un créneau découverte
         </Link>
       </div>
     </div>

--- a/src/lib/services.ts
+++ b/src/lib/services.ts
@@ -17,114 +17,264 @@ export type ServiceDetail = {
 
 export const servicesData: ServiceDetail[] = [
   {
-    slug: "captation-spectrale",
-    title: "Captation Spectrale",
-    subtitle: "Multi-cam, drone et plateau XR entièrement synchronisés",
-    problem: "Vous préparez un lancement stratégique ou un événement majeur qui exige une captation irréprochable sur chaque angle.",
+    slug: "entreprise",
+    title: "Films de marque & culture d'entreprise",
+    subtitle: "Positionnez votre équipe comme le média de référence de votre secteur",
+    problem:
+      "Vous devez incarner votre vision, vos expertises et vos talents avec un film premium qui suscite l'adhésion en interne comme en externe.",
     promise:
-      "Nous orchestrons une réalisation premium avec régie automatisée, robotique Seedance Pro et compositing temps réel pour délivrer un rendu broadcast immédiatement exploitable.",
-    stack: ["Seedance Pro", "DaVinci Resolve", "Blackmagic Atem Scripting", "Audio Suno AI"],
+      "Je conçois un récit cinématique qui mêle interviews, captations de terrain et séquences immersives pour révéler la personnalité de votre entreprise.",
+    stack: [
+      "Sony Burano 8K",
+      "DaVinci Resolve 19 Neural",
+      "Runway Gen-5 Enterprise",
+      "Adobe Premiere Pro Sensei",
+    ],
     deliverables: [
-      "Réalisations live multi-cam 12K",
-      "Mixage audio spatial et stems Suno",
-      "Capsules sociales instantanées",
+      "Film maître 16:9 calibré broadcast",
+      "3 déclinaisons 9:16 et 1:1 optimisées social",
+      "Pack photo + sound design original",
     ],
     phases: [
       {
-        title: "Pré-production",
-        description: "Repérages LiDAR, plan lumière anticipé par IA et trame éditoriale validée avec votre équipe.",
-        aiUpgrade: "Modélisation 3D Midjourney V7 et prévisualisation Kling 2.5 pour sécuriser les angles.",
+        title: "Préproduction stratégique",
+        description:
+          "Atelier vision, repérages immersifs et storyboard augmenté pour sécuriser chaque séquence clé.",
+        aiUpgrade:
+          "Prévisualisation Runway + Luma Ray pour valider les axes caméra et la lumière avant tournage.",
       },
       {
-        title: "Captation",
-        description: "Pilotage robotisé, switcher automatisé et overlay data en direct pour garantir la continuité de service.",
-        aiUpgrade: "Seedance Pro anticipe les mouvements clés et optimise les transitions caméra.",
+        title: "Tournage cinématique",
+        description:
+          "Interviews multicam, plans drones FPV et captation sonore double système avec mixage live.",
+        aiUpgrade: "Pilotage focus assisté par IA et script téléprompteur dynamique pour fluidifier les prises.",
       },
       {
-        title: "Post-événement",
-        description: "Montage express, corrections colorimétriques et exports multi-formats prêts à diffuser.",
-        aiUpgrade: "Scripts IA pour générer les accroches et CTA adaptés à chaque réseau.",
+        title: "Activation multicanale",
+        description:
+          "Montage narratif, color grading ACES, habillage graphique et exports calibrés pour chaque canal.",
+        aiUpgrade:
+          "Scripts LinkedIn & newsletter générés avec vérification humaine pour accélérer votre diffusion.",
       },
     ],
-    signatureMove: "Livraison d'une déclinaison 9:16 optimisée dans les 47 minutes suivant la fin de l'événement.",
+    signatureMove:
+      "Livraison d'une version teaser 45'' prête pour vos comités de direction en 72 heures.",
     metrics: [
-      { label: "Transitions caméra", value: "480", note: "pilotées par anticipation Seedance" },
-      { label: "Équipe plateau", value: "6", note: "réalisateurs, cadreurs et spécialistes IA" },
-      { label: "Taux de rétention", value: "+63%", note: "comparé à un livestream standard" },
+      { label: "Satisfaction direction", value: "98%", note: "mesurée sur 36 projets corporate" },
+      { label: "Itérations", value: "≤2", note: "grâce à la préparation éditoriale" },
+      { label: "Boost leads", value: "+61%", note: "impact moyen post diffusion" },
     ],
   },
   {
-    slug: "campagne-holo-sociale",
-    title: "Campagne Holo-Sociale",
-    subtitle: "Brand content orchestré pour chaque réseau et chaque format",
-    problem: "Vos audiences sont dispersées sur plusieurs plateformes et attendent des contenus différenciés mais cohérents.",
+    slug: "evenementiel",
+    title: "Aftermovies & captations événementielles",
+    subtitle: "Immortalisez l'énergie de vos événements avec une diffusion express",
+    problem:
+      "Vos participants attendent un contenu à chaud et vos sponsors veulent des assets prêts à partager dès le lendemain.",
     promise:
-      "Nous combinons narration, motion design et IA générative pour produire des campagnes multi-format parfaitement alignées avec votre image de marque.",
-    stack: ["Midjourney V7", "Veo 3", "Adobe After Effects", "Premiere Pro Sensei"],
-      deliverables: [
-        "Film héro + 12 contenus snack",
-        "Visuels corporate prêts à publier",
-        "Banque de visuels IA brandés",
-      ],
+      "Je couvre votre événement avec une équipe légère mais ultra équipée pour livrer un aftermovie vibrant et des capsules sociales instantanées.",
+    stack: ["FX6 Duo Multicam", "DJI Inspire 3", "Veo 3 Live", "Suno Studio Max"],
+    deliverables: [
+      "Aftermovie 90''", "Capsule verticale jour J", "Banque de plans bruts triés",
+    ],
     phases: [
       {
-        title: "Atelier stratégique",
-        description: "Analyse des personas, cadrage des messages clés et définition de la grille éditoriale.",
-        aiUpgrade: "Prompt engineering Midjourney V7 et génération de scripts multi-tonalité par GPT-Voix.",
+        title: "Cadrage & logistique",
+        description:
+          "Repérages techniques, déroulé chronologique et plan de captation multi-équipes.",
+        aiUpgrade: "Timeline dynamique Notion + alerte météo IA pour ajuster les équipes en temps réel.",
       },
       {
-        title: "Production",
-        description: "Tournages live, captations drone, motion design et avatars lip-sync selon les besoins.",
-        aiUpgrade: "LypSync V2 synchronise dialogues et voix générées en temps réel.",
+        title: "Tournage terrain",
+        description:
+          "Captation stabilisée, micro-trottoirs, drone FPV indoor et ambiance sonore immersive.",
+        aiUpgrade:
+          "Reconnaissance visage pour retrouver vos VIP et tagging automatique des séquences clés.",
       },
       {
-        title: "Déclinaisons",
-        description: "Montage modulaire, VFX data-driven et automatisation des exports selon les plateformes.",
-        aiUpgrade: "Veille tendance en temps réel pour ajuster les variations et recommandations de diffusion.",
+        title: "Montage à chaud",
+        description:
+          "Montage express sur station mobile, étalonnage LUT perso et intégration branding sponsor.",
+        aiUpgrade:
+          "Génération d'accroches et sous-titres multilingues par IA vérifiés en direct.",
       },
     ],
-    signatureMove: "Chaque déclinaison 9:16 intègre les optimisations IA nécessaires pour maximiser la rétention.",
+    signatureMove:
+      "Aftermovie livré en 24 h et stories verticales publiables pendant l'événement.",
     metrics: [
-      { label: "Temps de production", value: "12 jours", note: "du brief à la mise en ligne" },
-      { label: "Variations IA", value: "128", note: "prompts ajustés en continu" },
-      { label: "UGC généré", value: "x4", note: "par rapport à une campagne standard" },
+      { label: "Délai livraison", value: "24 h", note: "après clap de fin" },
+      { label: "Equipe terrain", value: "3", note: "opérateurs polyvalents + IA ops" },
+      { label: "Taux partage", value: "+74%", note: "vs. contenus non animés" },
     ],
   },
   {
-    slug: "programme-continuum",
-    title: "Programme Continuum",
-    subtitle: "Studio vidéo externalisé pour votre marque sur 12 mois",
-    problem: "Vous recherchez une production récurrente sans internaliser l'ensemble des compétences vidéo.",
+    slug: "immobilier",
+    title: "Visites premium & lancements immobiliers",
+    subtitle: "Valorisez chaque mètre carré avec une narration architecturale sur-mesure",
+    problem:
+      "Vos biens haut de gamme nécessitent un contenu qui révèle la lumière, la circulation et les signatures architecturales.",
     promise:
-      "Studio VBG agit comme votre cellule vidéo intégrée : plan éditorial, tournages mensuels, lives trimestriels et analyses de performance.",
-    stack: ["DaVinci Resolve", "Notion Automations", "Adobe Premiere Pro", "Veo 3", "Kling 2.5"],
+      "Je scénarise une visite immersive qui combine plan séquence stabilisé, drone FPV et motion design pour magnifier vos projets.",
+    stack: ["Insta360 Ace Pro", "DJI Avata 2", "Luma NeRF", "Unreal Engine 5.4"],
     deliverables: [
-      "Roadmap éditoriale évolutive",
-      "Plateau captation récurrent",
-      "Dashboard ROI et insights",
+      "Film visite 4K HDR",
+      "Plan masse animé & synthèses 3D",
+      "Pack d'annonces optimisées portals",
     ],
     phases: [
       {
-        title: "Onboarding",
-        description: "Audit des contenus existants, modélisation des audiences et définition des KPIs cibles.",
-        aiUpgrade: "Analyse sémantique GPT+ pour identifier les angles différenciants et opportunités éditoriales.",
+        title: "Préparation scénographique",
+        description:
+          "Moodboard lumière, repérage NeRF et script voix-off selon vos personas acquéreurs.",
+        aiUpgrade: "Projection 3D Luma pour tester les mouvements caméra et la mise en scène déco.",
       },
       {
-        title: "Production continue",
-        description: "Captations mensuelles, micro-formats récurrents et événements live trimestriels.",
-        aiUpgrade: "Planification automatisée et scripts IA personnalisés selon les actualités de votre marque.",
+        title: "Tournage sur site",
+        description:
+          "Travellings gimbal, drone intérieur/extérieur, timelapses et détails matières macro.",
+        aiUpgrade: "Stabilisation gyroscopique active + focus tracking IA sur les éléments différenciants.",
       },
       {
-        title: "Optimisation",
-        description: "Analyse de performance, recommandations éditoriales et ajustements créatifs en continu.",
-        aiUpgrade: "Dashboard IA pour générer des recommandations exploitables en un clic.",
+        title: "Post-production signature",
+        description:
+          "Voix-off, sound design, color grading neutre luxe et exports en plusieurs langues.",
+        aiUpgrade: "Génération de variantes de textes pour portails immobiliers et réseaux sociaux.",
       },
     ],
-    signatureMove: "Revue mensuelle structurée avec partage des indicateurs clés et arbitrages éditoriaux.",
+    signatureMove:
+      "Version courte verticale dédiée aux campagnes Meta Ads incluse dans chaque prestation.",
     metrics: [
-      { label: "Période", value: "12 mois", note: "offre renouvelable" },
-      { label: "ROI moyen", value: "x5.6", note: "sur les leads entrants" },
-      { label: "Charge opérationnelle", value: "-73%", note: "mesurée auprès de vos équipes marketing" },
+      { label: "Rdv qualifiés", value: "+38%", note: "moyenne observée sur 2024-2025" },
+      { label: "Tournage", value: "1 jour", note: "équipe réduite et agile" },
+      { label: "Variantes", value: "6", note: "formats livrés prêts à diffuser" },
+    ],
+  },
+  {
+    slug: "reseaux-sociaux",
+    title: "Content social & campagnes always-on",
+    subtitle: "Alimentez vos communautés avec des formats courts ultra performants",
+    problem:
+      "Vous devez publier régulièrement sans sacrifier la qualité ni l'alignement de marque.",
+    promise:
+      "Je mets en place une machine à contenus qui combine tournages agiles, IA générative et pilotage éditorial pour tenir la cadence.",
+    stack: ["Sony FX3", "Aputure Infinibar", "CapCut Pro 2025", "OpusClip AI"],
+    deliverables: [
+      "Série de 8 à 12 vidéos courtes/mois",
+      "Templates motion réutilisables",
+      "Kit miniatures & légendes optimisées",
+    ],
+    phases: [
+      {
+        title: "Sprint éditorial",
+        description:
+          "Calendrier thématique, scripts hooks et choix des trends adaptés à votre tonalité.",
+        aiUpgrade:
+          "Veille algorithmique TikTok/Instagram + scoring IA pour prioriser les concepts à fort potentiel.",
+      },
+      {
+        title: "Production agile",
+        description:
+          "Tournages batch, B-roll créatif, motion snack et captation audio autonome.",
+        aiUpgrade:
+          "Assistants IA pour générer variations de hook et sélectionner les meilleures prises.",
+      },
+      {
+        title: "Optimisation & pilotage",
+        description:
+          "Montage rapide, sous-titres animés, thumbnails générés et reporting mensuel.",
+        aiUpgrade:
+          "Analyse de performance automatisée avec recommandations prêtes à publier.",
+      },
+    ],
+    signatureMove: "Réunion éditoriale hebdo + drop de contenus prêts à programmer sous 48 h.",
+    metrics: [
+      { label: "Croissance moyenne", value: "+89%", note: "sur 90 jours" },
+      { label: "Cadence", value: "10+", note: "vidéos livrées / mois" },
+      { label: "Taux complétion", value: "65%", note: "moyenne des formats 9:16" },
+    ],
+  },
+  {
+    slug: "mariage",
+    title: "Films de mariage haute couture",
+    subtitle: "Un storytelling poétique pour revivre chaque émotion",
+    problem:
+      "Vous voulez un film sincère, élégant et intemporel qui capture vos proches autant que vos détails.",
+    promise:
+      "Je vous accompagne dès les préparatifs pour créer un film sur-mesure, tourné en analogique + numérique, livré avec un coffret exclusif.",
+    stack: ["Sony A1", "Leica Q3", "Kodak Super 8", "Sora Pro Colorist"],
+    deliverables: [
+      "Film signature 6-8 minutes",
+      "Teaser 60'' livré sous 5 jours",
+      "Galerie photo + mini site privé",
+    ],
+    phases: [
+      {
+        title: "Rencontre & intention",
+        description:
+          "Moodboard émotionnel, repérage des lieux et coordination avec wedding planner.",
+        aiUpgrade: "Assistant de style IA pour traduire vos inspirations en palette visuelle unique.",
+      },
+      {
+        title: "Jour J discret",
+        description:
+          "Captation cinématographique discrète, audio haute fidélité et moments volés.",
+        aiUpgrade:
+          "Reconnaissance visage pour identifier les proches prioritaires et ne manquer aucune émotion.",
+      },
+      {
+        title: "Montage émotion",
+        description:
+          "Montage musical, mixage binaural, étalonnage film et packaging collector.",
+        aiUpgrade:
+          "IA musicale pour adapter la bande sonore et générer une version rallongée sur demande.",
+      },
+    ],
+    signatureMove: "Coffret USB gravé + tirages fine art livrés avec le film final.",
+    metrics: [
+      { label: "Livraison teaser", value: "5 jours", note: "après le mariage" },
+      { label: "Satisfaction couples", value: "100%", note: "note moyenne 5/5" },
+      { label: "Présence", value: "14 h", note: "de couverture continue" },
+    ],
+  },
+  {
+    slug: "motion-design-ia",
+    title: "Motion design augmenté par l'IA",
+    subtitle: "Expliquez vos innovations avec des visuels ultra fluides",
+    problem:
+      "Vos produits tech ou SaaS sont complexes et nécessitent une pédagogie visuelle claire et spectaculaire.",
+    promise:
+      "Je mixe motion design, 3D générative et avatars intelligents pour créer une vidéo explicative mémorable.",
+    stack: ["After Effects 2025", "Blender Geometry Nodes", "Runway Gen-5", "ElevenLabs Dubbing"],
+    deliverables: [
+      "Film motion 90''",
+      "Cutdowns 30'' et 15''",
+      "Kit illustrations + loops UI",
+    ],
+    phases: [
+      {
+        title: "Scénarisation",
+        description:
+          "Workshop script, board illustré et définition de la charte motion.",
+        aiUpgrade: "Storyboards génératifs et voix témoin IA pour valider les rythmes.",
+      },
+      {
+        title: "Production visuelle",
+        description:
+          "Animation 2D/3D, simulations physiques et intégration de data en temps réel.",
+        aiUpgrade: "Runway Gen-5 pour textures dynamiques et avatars de démonstration.",
+      },
+      {
+        title: "Optimisation diffusion",
+        description:
+          "Mixage audio multilingue, sous-titres adaptatifs et exports pour webinaire / réseaux.",
+        aiUpgrade: "Dubbing ElevenLabs et QA automatique des contrastes pour l'accessibilité.",
+      },
+    ],
+    signatureMove: "Version multilingue (FR/EN/ES) prête à livrer grâce au pipeline de doublage IA.",
+    metrics: [
+      { label: "Temps prod", value: "21 jours", note: "cycle complet" },
+      { label: "Variantes", value: "9", note: "formats prêts à l'emploi" },
+      { label: "Compréhension", value: "+48%", note: "sur vos démos produit" },
     ],
   },
 ];

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,0 +1,101 @@
+import { Link } from "react-router-dom";
+
+import { servicesData } from "@/lib/services";
+
+const About = () => {
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-white">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background:
+            "radial-gradient(circle at 20% 20%, rgba(56,189,248,0.18), transparent 55%), radial-gradient(circle at 80% 60%, rgba(236,72,153,0.15), transparent 60%), linear-gradient(160deg, rgba(15,23,42,0.92), rgba(15,23,42,0.72))",
+        }}
+      />
+      <div className="relative mx-auto flex w-full max-w-5xl flex-col gap-16 px-6 pb-24 pt-28 sm:px-10">
+        <header className="space-y-6">
+          <p className="text-xs font-semibold uppercase tracking-[0.5em] text-white/60">À propos</p>
+          <h1 className="text-4xl font-extrabold sm:text-5xl">Alex VBG, vidéaste freelance & directeur artistique</h1>
+          <p className="max-w-3xl text-base text-white/70">
+            Depuis 2016, j'accompagne des marques, des startups et des agences pour produire des films qui mixent esthétique
+            cinématographique, narration incarnée et innovation technologique. Basé à Paris, je me déplace en France et en Europe
+            avec un studio mobile pensé pour 2025.
+          </p>
+        </header>
+
+        <section className="grid gap-8 rounded-[3rem] border border-white/10 bg-white/5 p-10 lg:grid-cols-3">
+          <div className="space-y-3">
+            <h2 className="text-xl font-semibold">Approche</h2>
+            <p className="text-sm text-white/70">
+              Une relation directe, des process transparents et une obsession pour le détail. Du cadrage éditorial à la diffusion,
+              tout est orchestré pour vous faire gagner du temps et de l'impact.
+            </p>
+          </div>
+          <div className="space-y-3">
+            <h2 className="text-xl font-semibold">Équipement</h2>
+            <p className="text-sm text-white/70">
+              Sony Burano 8K, FX6, FX3, drones DJI Inspire 3 et Avata 2, optiques G Master, set audio Sennheiser 6000, éclairage
+              Aputure Infinibar, station mobile M3 Max.
+            </p>
+          </div>
+          <div className="space-y-3">
+            <h2 className="text-xl font-semibold">Réseau</h2>
+            <p className="text-sm text-white/70">
+              Un collectif d'opérateurs drone, motion designers, maquilleurs et ingénieurs du son pour dimensionner les équipes
+              selon votre projet.
+            </p>
+          </div>
+        </section>
+
+        <section className="space-y-6">
+          <h2 className="text-3xl font-extrabold">Méthodologie</h2>
+          <div className="grid gap-6 lg:grid-cols-3">
+            {["Co-création", "Production", "Diffusion"].map((step, index) => (
+              <div key={step} className="rounded-[2.5rem] border border-white/10 bg-slate-900/60 p-6">
+                <p className="text-[0.65rem] font-semibold uppercase tracking-[0.45em] text-white/60">Phase 0{index + 1}</p>
+                <h3 className="mt-3 text-xl font-semibold text-white">{step}</h3>
+                <p className="mt-3 text-sm text-white/70">
+                  {index === 0 && "Atelier vision, moodboard, repérages et script validés ensemble."}
+                  {index === 1 && "Tournages agiles, direction artistique exigeante et coordination des talents."}
+                  {index === 2 && "Montage, déclinaisons, sous-titres dynamiques et accompagnement à la mise en ligne."}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="space-y-6">
+          <h2 className="text-3xl font-extrabold">Services phares</h2>
+          <div className="grid gap-6 lg:grid-cols-2">
+            {servicesData.slice(0, 4).map((service) => (
+              <article key={service.slug} className="rounded-[2.5rem] border border-white/10 bg-slate-900/60 p-6">
+                <p className="text-[0.65rem] font-semibold uppercase tracking-[0.45em] text-white/60">{service.slug.replaceAll("-", " ")}</p>
+                <h3 className="mt-3 text-2xl font-semibold text-white">{service.title}</h3>
+                <p className="mt-3 text-sm text-white/70">{service.subtitle}</p>
+                <Link to={`/services/${service.slug}`} className="mt-5 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.35em] text-sky-200">
+                  Voir le détail
+                </Link>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="rounded-[3rem] border border-white/10 bg-white/5 p-10 text-center text-sm text-white/70">
+          <p className="text-xs uppercase tracking-[0.45em] text-white/60">Next step</p>
+          <h2 className="mt-4 text-3xl font-extrabold text-white">Envie d'échanger autour de votre prochain film ?</h2>
+          <div className="mt-6 flex flex-wrap justify-center gap-4">
+            <Link to="/quote" className="rounded-full border border-sky-300/40 bg-sky-500/20 px-6 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-white">
+              Réserver un call
+            </Link>
+            <Link to="/realisations" className="rounded-full border border-white/30 bg-white/10 px-6 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-white/70 hover:text-white">
+              Voir les réalisations
+            </Link>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default About;

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,0 +1,150 @@
+import { FormEvent, useState } from "react";
+
+import { useStudio } from "@/context/StudioContext";
+import { cn } from "@/lib/utils";
+
+const options = [
+  { value: "appel", label: "Appel visio" },
+  { value: "rdv", label: "Rendez-vous sur site" },
+  { value: "atelier", label: "Atelier cadrage" },
+];
+
+const Contact = () => {
+  const { recordContactRequest } = useStudio();
+  const [formState, setFormState] = useState<"idle" | "sending" | "sent">("idle");
+  const [form, setForm] = useState({
+    name: "",
+    email: "",
+    projectSpark: "",
+    urgency: "cette-semaine" as const,
+    format: options[0].value,
+  });
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!form.name || !form.email || !form.projectSpark) {
+      return;
+    }
+    setFormState("sending");
+    recordContactRequest({
+      name: form.name,
+      email: form.email,
+      projectSpark: `${form.projectSpark}\nFormat souhaité : ${form.format}`,
+      urgency: form.urgency,
+    });
+    setTimeout(() => {
+      setFormState("sent");
+      setForm({ name: "", email: "", projectSpark: "", urgency: "cette-semaine", format: options[0].value });
+    }, 400);
+  };
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-white">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background:
+            "radial-gradient(circle at 10% 15%, rgba(56,189,248,0.18), transparent 55%), radial-gradient(circle at 85% 70%, rgba(236,72,153,0.12), transparent 60%), linear-gradient(160deg, rgba(15,23,42,0.95), rgba(15,23,42,0.72))",
+        }}
+      />
+      <div className="relative mx-auto flex w-full max-w-4xl flex-col gap-12 px-6 pb-24 pt-28 sm:px-10">
+        <header className="space-y-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.5em] text-white/60">Contact</p>
+          <h1 className="text-4xl font-extrabold sm:text-5xl">Parlons de votre prochain film</h1>
+          <p className="max-w-2xl text-sm text-white/70">
+            Expliquez-moi votre projet, je vous réponds dans la journée avec un plan de production, un budget indicatif et mes
+            prochaines disponibilités.
+          </p>
+        </header>
+
+        <form onSubmit={handleSubmit} className="space-y-6 rounded-[3rem] border border-white/10 bg-white/5 p-10 shadow-[0_24px_120px_rgba(56,189,248,0.18)]">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="flex flex-col gap-2 text-sm text-white/70">
+              Nom
+              <input
+                type="text"
+                value={form.name}
+                onChange={(event) => setForm((current) => ({ ...current, name: event.target.value }))}
+                className="rounded-2xl border border-white/20 bg-white/10 px-4 py-3 text-sm text-white placeholder:text-white/50 focus:border-sky-400 focus:outline-none"
+                placeholder="Prénom Nom"
+                required
+              />
+            </label>
+            <label className="flex flex-col gap-2 text-sm text-white/70">
+              Email
+              <input
+                type="email"
+                value={form.email}
+                onChange={(event) => setForm((current) => ({ ...current, email: event.target.value }))}
+                className="rounded-2xl border border-white/20 bg-white/10 px-4 py-3 text-sm text-white placeholder:text-white/50 focus:border-sky-400 focus:outline-none"
+                placeholder="vous@entreprise.com"
+                required
+              />
+            </label>
+          </div>
+          <label className="flex flex-col gap-2 text-sm text-white/70">
+            Projet
+            <textarea
+              value={form.projectSpark}
+              onChange={(event) => setForm((current) => ({ ...current, projectSpark: event.target.value }))}
+              className="min-h-[160px] rounded-2xl border border-white/20 bg-white/10 px-4 py-3 text-sm text-white placeholder:text-white/50 focus:border-sky-400 focus:outline-none"
+              placeholder="Format souhaité, objectifs, ambiance, échéance..."
+              required
+            />
+          </label>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="flex flex-col gap-2 text-sm text-white/70">
+              Urgence
+              <select
+                value={form.urgency}
+                onChange={(event) => setForm((current) => ({ ...current, urgency: event.target.value as typeof form.urgency }))}
+                className="rounded-2xl border border-white/20 bg-white/10 px-4 py-3 text-sm text-white focus:border-sky-400 focus:outline-none"
+              >
+                <option value="hier">Projet urgent</option>
+                <option value="cette-semaine">Démarrage cette semaine</option>
+                <option value="quand-c-est-parfait">Je planifie tranquillement</option>
+              </select>
+            </label>
+            <fieldset className="space-y-2 text-sm text-white/70">
+              <legend className="text-xs uppercase tracking-[0.35em] text-white/60">Format d'échange</legend>
+              <div className="grid gap-2">
+                {options.map((option) => {
+                  const isActive = form.format === option.value;
+                  return (
+                    <label
+                      key={option.value}
+                      className={cn(
+                        "flex cursor-pointer items-center justify-between rounded-2xl border px-4 py-3 text-xs font-semibold uppercase tracking-[0.35em]",
+                        isActive ? "border-sky-400/60 bg-sky-500/20 text-white" : "border-white/20 bg-white/10 text-white/70"
+                      )}
+                    >
+                      <input
+                        type="radio"
+                        name="contact-format"
+                        value={option.value}
+                        checked={isActive}
+                        onChange={(event) => setForm((current) => ({ ...current, format: event.target.value }))}
+                        className="hidden"
+                      />
+                      {option.label}
+                    </label>
+                  );
+                })}
+              </div>
+            </fieldset>
+          </div>
+          <button
+            type="submit"
+            className="inline-flex w-full items-center justify-center gap-3 rounded-full bg-gradient-to-r from-sky-500 via-indigo-500 to-fuchsia-500 px-8 py-4 text-sm font-bold uppercase tracking-[0.35em] text-white shadow-[0_18px_80px_rgba(59,130,246,0.4)] disabled:cursor-not-allowed disabled:opacity-60"
+            disabled={formState === "sending"}
+          >
+            {formState === "sending" ? "Envoi..." : formState === "sent" ? "Message envoyé" : "Envoyer"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default Contact;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,583 +1,463 @@
 import { Link } from "react-router-dom";
-import { useEffect, useState } from "react";
+import { FormEvent, useMemo, useState } from "react";
+
 import HeroRibbon from "@/components/HeroRibbon";
 import { useStudio } from "@/context/StudioContext";
 import { servicesData } from "@/lib/services";
 import { cn } from "@/lib/utils";
 
-const heroHooks = [
-  "Studios holographiques synchronisés en temps réel",
-  "Orchestration IA + équipes de plateau pour chaque séquence",
-  "Monitoring carbone, droits et data-contracts intégrés",
+const heroMetrics = [
+  { label: "Films livrés", value: "120+", note: "corporate, events & marques" },
+  { label: "Note clients", value: "4.9/5", note: "sur 2023-2025" },
+  { label: "Délai moyen", value: "12 j", note: "de la prod à la diffusion" },
 ];
 
-const heroNavigationSegments = [
+const creativePrinciples = [
   {
-    id: "immersive",
-    badge: "Cinematic AI",
-    label: "Studios immersifs",
-    descriptor: "Captations XR volumétriques en 12K et audio spatial certifié.",
+    title: "Narration incarnée",
+    description:
+      "Un accompagnement auteur pour révéler vos talents, vos clients et vos valeurs avec un ton juste et mémorable.",
   },
   {
-    id: "campaigns",
-    badge: "Growth",
-    label: "Campagnes sociales",
-    descriptor: "Formats courts orchestrés et optimisés par la data créative.",
+    title: "Pipeline hybride",
+    description:
+      "Caméras cinéma, drone FPV, studio mobile et IA générative dernière génération pour fluidifier chaque étape.",
   },
   {
-    id: "live",
-    badge: "LiveOps",
-    label: "Diffusions live",
-    descriptor: "Plateaux hybrides, chatbots de modération et analytics temps réel.",
-  },
-  {
-    id: "academy",
-    badge: "Enablement",
-    label: "Formations internes",
-    descriptor: "Learning immersif, modules VR et supports interactifs pour vos équipes.",
+    title: "Diffusion pilotée",
+    description:
+      "Déclinaisons verticales, sous-titres dynamiques, templates motion et recommandations éditoriales clés en main.",
   },
 ];
 
-const heroOperationalMetrics = [
-  { id: "availability", value: "24/7", label: "Supervision hybride" },
-  { id: "kickoff", value: "02 h", label: "Kick-off moyen" },
-  { id: "satisfaction", value: "99,3 %", label: "Satisfaction client" },
+const stackHighlights = [
+  {
+    title: "Capture cinématique",
+    description: "Sony Burano 8K, FX6 duo, DJI Inspire 3 et optiques G Master pour un rendu cinéma en toutes situations.",
+  },
+  {
+    title: "IA créative",
+    description: "Runway Gen-5 Enterprise, Sora Pro Colorist, Luma Ray Reconstruction, ElevenLabs Dubbing.",
+  },
+  {
+    title: "Montage & finishing",
+    description: "DaVinci Resolve 19 Neural, Adobe Premiere Pro Sensei et mixage Dolby Atmos ready.",
+  },
+  {
+    title: "Pilotage projet",
+    description: "Notion 2025, automation CRM et dashboards personnalisés pour suivre production et ROI.",
+  },
 ];
 
-const techStack = [
-  "Runway Gen-5 Enterprise",
-  "Sora Pro 2",
-  "Kling 3 XR",
-  "Luma Ray Reconstruction",
-  "Suno Studio Max",
-  "Lyrebird Sync V3",
-  "DaVinci Resolve Neural",
-  "Adobe Video Sensei",
+const testimonials = [
+  {
+    quote:
+      "Alex a capté l'énergie de notre équipe et a livré un film corporate qui a fait l'unanimité auprès de notre COMEX.",
+    author: "Claire L.",
+    role: "Directrice communication, Helia Labs",
+  },
+  {
+    quote:
+      "Notre aftermovie était prêt dès le lendemain avec toutes les déclinaisons sociales. Sponsors et participants ont adoré.",
+    author: "Marc D.",
+    role: "Fondateur, Paris Tech Summit",
+  },
+  {
+    quote:
+      "Une vraie vision créative et un accompagnement rigoureux. Les vidéos sociales performent depuis trois mois d'affilée !",
+    author: "Sonia V.",
+    role: "Head of Brand, Nova SaaS",
+  },
 ];
+
+const urgencyOptions = [
+  { value: "hier", label: "Projet urgent" },
+  { value: "cette-semaine", label: "Démarrage cette semaine" },
+  { value: "quand-c-est-parfait", label: "Je planifie tranquillement" },
+] as const;
 
 const Index = () => {
-  const { portfolioItems, recordContactRequest, user } = useStudio();
-  const [hookIndex, setHookIndex] = useState(0);
-  const [contactSent, setContactSent] = useState(false);
-  const [heroImageLoaded, setHeroImageLoaded] = useState(false);
-  const [heroImageError, setHeroImageError] = useState(false);
-  const [isRibbonVisible, setIsRibbonVisible] = useState(true);
+  const { portfolioItems, recordContactRequest } = useStudio();
+  const [formState, setFormState] = useState<"idle" | "sending" | "sent">("idle");
   const [form, setForm] = useState({
     name: "",
     email: "",
     projectSpark: "",
-    urgency: "hier" as const,
+    urgency: urgencyOptions[1].value,
   });
 
-  const heroProject = portfolioItems[0];
-  const heroHookCount = heroHooks.length;
-  const heroTools = heroProject?.aiTools?.slice(0, 3) ?? [];
+  const featuredProjects = useMemo(() => portfolioItems.slice(0, 3), [portfolioItems]);
+  const highlightServices = useMemo(() => servicesData.slice(0, 3), []);
 
-  useEffect(() => {
-    if (typeof window === "undefined") return;
+  const onSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!form.name || !form.email || !form.projectSpark) {
+      return;
+    }
+    if (formState === "sending") {
+      return;
+    }
 
-    let ticking = false;
-
-    const updateVisibility = () => {
-      setIsRibbonVisible(window.scrollY <= 40);
-    };
-
-    const handleScroll = () => {
-      if (ticking) return;
-      ticking = true;
-      window.requestAnimationFrame(() => {
-        updateVisibility();
-        ticking = false;
-      });
-    };
-
-    updateVisibility();
-    window.addEventListener("scroll", handleScroll, { passive: true });
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
-
-  useEffect(() => {
-    if (heroHookCount <= 1 || typeof window === "undefined") return;
-    const timer = window.setInterval(() => {
-      setHookIndex((index) => (index + 1) % heroHookCount);
-    }, 6000);
-    return () => window.clearInterval(timer);
-  }, [heroHookCount]);
-
-  useEffect(() => {
-    setHeroImageLoaded(false);
-    setHeroImageError(false);
-  }, [heroProject?.thumbnail]);
+    setFormState("sending");
+    recordContactRequest({
+      name: form.name,
+      email: form.email,
+      projectSpark: form.projectSpark,
+      urgency: form.urgency as (typeof urgencyOptions)[number]["value"],
+    });
+    setTimeout(() => {
+      setFormState("sent");
+      setForm({ name: "", email: "", projectSpark: "", urgency: urgencyOptions[1].value });
+    }, 400);
+  };
 
   return (
     <div className="relative min-h-screen overflow-x-hidden bg-slate-950 text-white">
-      <HeroRibbon visible={isRibbonVisible} />
       <div
+        aria-hidden
         className="pointer-events-none absolute inset-0"
         style={{
           background:
-            "radial-gradient(circle at 15% 25%, hsla(var(--visual-secondary) / 0.32), transparent 55%), radial-gradient(circle at 82% 65%, hsla(var(--visual-accent) / 0.24), transparent 60%), linear-gradient(160deg, hsl(266 65% 11% / 0.9), hsl(335 70% 12% / 0.78))",
+            "radial-gradient(circle at 10% 15%, rgba(56,189,248,0.18), transparent 55%), radial-gradient(circle at 85% 30%, rgba(244,63,94,0.15), transparent 60%), linear-gradient(160deg, rgba(15,23,42,0.9), rgba(15,23,42,0.65))",
         }}
       />
-      <div
-        className="pointer-events-none absolute inset-0 opacity-45"
-        style={{
-          background:
-            "radial-gradient(circle at 50% 50%, rgba(255,255,255,0.06), transparent 70%), linear-gradient(120deg, rgba(15,118,110,0.08), transparent 55%)",
-        }}
-      />
-      <div className="relative">
-        <header className="relative isolate overflow-hidden">
-          <div
-            className="pointer-events-none absolute inset-0"
-            style={{
-              background:
-                "radial-gradient(circle at 12% 18%, hsla(var(--visual-secondary) / 0.35), transparent 55%), radial-gradient(circle at 85% 35%, hsla(var(--visual-accent) / 0.28), transparent 60%), linear-gradient(160deg, hsla(326 66% 20% / 0.85), hsla(258 62% 14% / 0.8))",
-            }}
-          />
-          <div
-            className="pointer-events-none absolute inset-0 opacity-50"
-            style={{
-              background:
-                "radial-gradient(circle at 50% 80%, rgba(255,255,255,0.06), transparent 68%), linear-gradient(120deg, rgba(255,255,255,0.04), transparent 55%)",
-            }}
-          />
-          <div className="relative mx-auto max-w-6xl px-6 pb-24 pt-28 sm:pt-36 lg:pb-32">
-            <div className="grid items-center gap-16 lg:grid-cols-[1.1fr_0.9fr]">
-              <div className="space-y-8">
-                <span className="inline-flex items-center gap-3 rounded-full border border-white/20 bg-white/10 px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-white/75 backdrop-blur">
-                  Studio VBG · Communication Engine
+      <HeroRibbon />
+      <main className="relative mx-auto flex w-full max-w-6xl flex-col gap-24 px-6 pb-32 pt-32 sm:px-10 lg:gap-32">
+        <header className="relative overflow-hidden rounded-[3.25rem] border border-white/10 bg-white/5 p-12 shadow-[0_24px_120px_rgba(56,189,248,0.35)] backdrop-blur">
+          <div className="absolute -top-24 right-16 hidden h-64 w-64 rounded-full bg-sky-500/40 blur-3xl lg:block" aria-hidden />
+          <div className="absolute -bottom-28 left-10 hidden h-64 w-64 rounded-full bg-fuchsia-500/30 blur-3xl lg:block" aria-hidden />
+          <div className="relative grid gap-12 lg:grid-cols-[1.25fr_1fr] lg:items-center">
+            <div className="space-y-8">
+              <span className="inline-flex items-center gap-3 rounded-full border border-white/20 bg-white/10 px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.45em] text-white/70">
+                Alex VBG · Vidéaste Freelance 2025
+              </span>
+              <h1 className="text-4xl font-black uppercase leading-[1.05] sm:text-5xl lg:text-[3.5rem]">
+                <span className="block text-xs font-semibold uppercase tracking-[0.6em] text-white/50">
+                  Films, contenus & experiences vidéo
                 </span>
-                <h1 className="text-4xl font-black uppercase leading-[1.05] sm:text-5xl lg:text-[3.75rem]">
-                  <span className="block text-xs font-semibold uppercase tracking-[0.55em] text-white/55">
-                    Operating system de communication
-                  </span>
-                  <span className="mt-4 block text-[2.75rem] leading-[1.05] sm:text-[3.5rem] lg:text-[4.25rem]">
-                    votre communication orchestrée par{" "}
-                    <span className="text-transparent bg-gradient-to-r from-sky-400 via-indigo-500 to-violet-500 bg-clip-text">
-                      Studio&nbsp;VBG
-                    </span>
-                  </span>
-                </h1>
-                <p className="max-w-xl text-lg text-white/75">
-                  Studio VBG orchestre vos productions de marque avec une pipeline 2025 mêlant
-                  captation premium, intelligence artificielle générative et diffusion
-                  omnicanale totalement maîtrisée.
-                </p>
-                <div className="flex flex-wrap gap-4 pt-4">
-                  <Link
-                    to="/quote"
-                    className="inline-flex items-center gap-3 rounded-full bg-gradient-to-r from-sky-500 via-indigo-500 to-violet-500 px-8 py-4 text-sm font-bold uppercase tracking-[0.35em] text-white shadow-[0_18px_80px_rgba(59,130,246,0.4)] transition-transform duration-300 hover:translate-y-[-2px]"
-                  >
-                    Planifier un workshop
-                  </Link>
-                  <Link
-                    to="/services"
-                    className="inline-flex items-center gap-3 rounded-full border border-white/30 px-8 py-4 text-sm font-bold uppercase tracking-[0.35em] text-white/70 transition-colors duration-300 hover:text-white"
-                  >
-                    Découvrir nos offres
-                  </Link>
-                </div>
-                <div className="flex items-center gap-3 pt-6 text-xs font-semibold uppercase tracking-[0.35em] text-white/60">
-                  <span className="inline-flex h-2 w-2 rounded-full bg-gradient-to-r from-sky-500 to-indigo-500 shadow-[0_0_0_6px_rgba(59,130,246,0.35)]" />
-                  <span>{heroHooks[hookIndex]}</span>
-                </div>
+                <span className="mt-4 block text-[2.75rem] leading-[1.05] sm:text-[3.5rem] lg:text-[4.25rem]">
+                  Vos histoires méritent un regard cinématique et une diffusion maîtrisée.
+                </span>
+              </h1>
+              <p className="max-w-2xl text-lg text-white/75">
+                Création de films d'entreprise, aftermovies, contenus social et motion design augmenté par l'IA. Une approche agile,
+                humaine et technologique pour amplifier votre marque.
+              </p>
+              <div className="flex flex-wrap gap-4">
+                <Link
+                  to="/quote"
+                  className="inline-flex items-center gap-3 rounded-full bg-gradient-to-r from-sky-500 via-indigo-500 to-fuchsia-500 px-8 py-4 text-sm font-bold uppercase tracking-[0.35em] text-white shadow-[0_18px_80px_rgba(59,130,246,0.4)] transition-transform duration-300 hover:-translate-y-0.5"
+                >
+                  Programmer un appel créatif
+                </Link>
+                <Link
+                  to="/services"
+                  className="inline-flex items-center gap-3 rounded-full border border-white/30 px-8 py-4 text-sm font-bold uppercase tracking-[0.35em] text-white/70 transition-colors duration-300 hover:text-white"
+                >
+                  Voir les services 2025
+                </Link>
               </div>
-
-              <div className="relative">
-                <div className="absolute -inset-10 rounded-[3.5rem] bg-gradient-to-br from-sky-500/25 via-transparent to-indigo-500/25 blur-3xl" />
-                <div className="relative overflow-hidden rounded-[3rem] border border-white/15 bg-white/10 shadow-[0_40px_140px_rgba(59,130,246,0.35)] backdrop-blur">
-                  <div className="absolute inset-0 bg-gradient-to-br from-white/10 via-transparent to-white/10 opacity-60" />
-                  <div className="relative">
-                    <div className="relative h-[420px] overflow-hidden rounded-[2.5rem]">
-                      <div
-                        className={cn(
-                          "absolute inset-0 bg-gradient-to-br opacity-70",
-                          heroProject?.gradient ?? "from-sky-500 via-indigo-500 to-violet-600",
-                        )}
-                      />
-                      {!heroImageError && heroProject?.thumbnail ? (
-                        <img
-                          src={heroProject.thumbnail}
-                          alt={heroProject.title}
-                          onLoad={() => setHeroImageLoaded(true)}
-                          onError={() => setHeroImageError(true)}
-                          className={cn(
-                            "absolute inset-0 h-full w-full object-cover object-center transition duration-700",
-                            heroImageLoaded ? "scale-100 opacity-100" : "scale-105 opacity-0",
-                          )}
-                        />
-                      ) : (
-                        <div className="relative z-10 flex h-full w-full flex-col items-center justify-center gap-3 bg-[#0a1124] text-center">
-                          <span className="text-3xl">🎨</span>
-                          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-white/70">Prototype en préparation</p>
-                          <p className="text-xs text-white/60">L'image du projet sera bientôt disponible.</p>
-                        </div>
-                      )}
-                      <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-[#0b0617]/90 via-[#0b0617]/35 to-transparent" />
-                    </div>
-
-                    <div className="absolute left-8 top-8 inline-flex items-center gap-2 rounded-full border border-white/30 bg-black/40 px-4 py-2 text-[0.6rem] font-semibold uppercase tracking-[0.35em] text-white/75 backdrop-blur">
-                      {heroProject?.category ?? "Featured"}
-                    </div>
-
-                    <div className="absolute inset-x-0 bottom-0 rounded-b-[3rem] bg-gradient-to-t from-[#0b0617]/95 via-[#0b0617]/55 to-transparent px-8 pb-10 pt-16">
-                      <div className="flex flex-wrap items-end justify-between gap-6">
-                        <div className="space-y-3">
-                          <p className="text-xs font-semibold uppercase tracking-[0.35em] text-white/45">En orchestration</p>
-                          <p className="text-2xl font-bold text-white">{heroProject?.title ?? "Votre prochaine campagne"}</p>
-                          <p className="text-sm text-white/70">
-                            {heroProject?.tagline ?? "Écosystème visuel modulable prêt pour chaque activation pilotée par KPI."}
-                          </p>
-                          <div className="flex flex-wrap gap-2 text-[0.55rem] font-semibold uppercase tracking-[0.3em] text-white/45">
-                            {heroTools.map((tool) => (
-                              <span key={tool} className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-3 py-1">
-                                {tool}
-                              </span>
-                            ))}
-                          </div>
-                        </div>
-                        <div className="flex flex-col items-end gap-2 text-[0.6rem] font-semibold uppercase tracking-[0.35em] text-white/55">
-                          {heroProject?.duration ? (
-                            <span className="rounded-full border border-white/20 bg-white/10 px-3 py-1">{heroProject.duration}</span>
-                          ) : null}
-                          {heroProject?.year ? (
-                            <span className="rounded-full border border-white/20 bg-white/10 px-3 py-1">{heroProject.year}</span>
-                          ) : null}
-                        </div>
-                      </div>
-                    </div>
+              <div className="grid gap-6 pt-6 sm:grid-cols-3">
+                {heroMetrics.map((metric) => (
+                  <div key={metric.label} className="rounded-3xl border border-white/10 bg-white/5 p-5">
+                    <p className="text-xs uppercase tracking-[0.35em] text-white/60">{metric.label}</p>
+                    <p className="mt-3 text-3xl font-semibold text-white">{metric.value}</p>
+                    <p className="text-xs text-white/60">{metric.note}</p>
                   </div>
-                </div>
+                ))}
               </div>
             </div>
-
-            <div className="mt-20 space-y-8">
-              <div className="grid gap-6 lg:grid-cols-[1.9fr_1fr]">
-                <nav className="grid gap-4 sm:grid-cols-2">
-                  {heroNavigationSegments.map((segment, index) => (
-                    <div
-                      key={segment.id}
-                      className={cn(
-                        "group relative overflow-hidden rounded-[1.75rem] border border-white/12 bg-white/5 p-6 transition-transform duration-500 hover:-translate-y-1",
-                        index === 0
-                          ? "shadow-[0_30px_110px_rgba(236,72,153,0.2)] visual-accent-hover-shadow"
-                          : "shadow-[0_24px_90px_rgba(14,165,233,0.18)]",
-                      )}
-                    >
-                      <span className="absolute inset-0 translate-y-full bg-gradient-to-t from-cyan-500/25 via-transparent to-transparent opacity-0 transition-transform duration-700 group-hover:translate-y-0 group-hover:opacity-100 visual-accent-gradient" />
-                      <div className="relative flex flex-col gap-3">
-                        <span className="inline-flex w-fit items-center gap-2 rounded-full border border-white/15 bg-white/10 px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-[0.35em] text-cyan-100/80 visual-accent-text-strong">
-                          {segment.badge}
-                        </span>
-                        <p className="text-xl font-bold text-white">{segment.label}</p>
-                        <p className="text-sm text-white/65">{segment.descriptor}</p>
-                      </div>
-                    </div>
-                  ))}
-                </nav>
-
-                <aside className="flex h-full flex-col gap-6 rounded-[2rem] border border-white/10 bg-white/5 p-6 shadow-[0_30px_110px_rgba(56,189,248,0.18)] visual-accent-veil">
-                  <div className="space-y-3">
-                    <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">
-                      Stack opérée en continu
-                    </p>
-                    <div className="flex flex-wrap gap-2 text-xs text-cyan-100/80 visual-accent-text-strong">
-                      {heroTools.length > 0 ? (
-                        heroTools.map((tool) => (
-                          <span key={tool} className="rounded-full bg-cyan-500/20 visual-accent-bg px-3 py-1">
-                            {tool}
-                          </span>
-                        ))
-                      ) : (
-                        <span className="rounded-full border border-white/15 bg-white/10 px-3 py-1 text-white/70">
-                          Stack en cours de mise à jour
-                        </span>
-                      )}
-                    </div>
-                  </div>
-
-                  <dl className="grid gap-3 sm:grid-cols-3">
-                    {heroOperationalMetrics.map((metric) => (
-                      <div
-                        key={metric.id}
-                        className="rounded-2xl border border-white/10 bg-white/5 p-4 text-center shadow-[0_18px_60px_rgba(56,189,248,0.12)]"
-                      >
-                        <dt className="text-xs uppercase tracking-[0.3em] text-white/55">{metric.label}</dt>
-                        <dd className="mt-2 text-2xl font-semibold text-white">{metric.value}</dd>
-                      </div>
-                    ))}
-                  </dl>
-
-                  <Link
-                    to="/portfolio"
-                    className="mt-auto inline-flex items-center justify-center gap-3 rounded-full border border-cyan-200/40 visual-accent-border bg-cyan-500/20 visual-accent-bg px-6 py-3 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-white transition-transform duration-300 hover:-translate-y-1"
-                  >
-                    Voir le portfolio <span className="text-base">➜</span>
-                  </Link>
-                </aside>
-              </div>
-
-              <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-4">
-                {portfolioItems.slice(0, 4).map((project) => (
-                  <Link
-                    key={project.id}
-                    to="/portfolio"
-                    className="group relative block overflow-hidden rounded-[1.75rem] border border-white/10 bg-white/5 shadow-[0_30px_110px_rgba(59,130,246,0.18)] transition-transform duration-500 hover:-translate-y-2"
-                    aria-label={`Voir le projet ${project.title} dans le portfolio`}
-                  >
-                    {project.thumbnail ? (
-                      <img
-                        src={project.thumbnail}
-                        alt={`Aperçu du projet ${project.title}`}
-                        className="absolute inset-0 h-full w-full object-cover transition-transform duration-700 group-hover:scale-105"
-                      />
-                    ) : (
-                      <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-sky-500/30 via-indigo-500/20 to-slate-900/40 text-sm uppercase tracking-[0.3em] text-white/70">
-                        Aperçu en attente
-                      </div>
-                    )}
-                    <div className="absolute inset-0 bg-gradient-to-b from-transparent via-[#0b0617]/30 to-[#0b0617]/90" />
-                    <div className="absolute left-6 top-6 inline-flex items-center gap-2 rounded-full border border-white/25 bg-white/10 px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-[0.3em] text-white/70">
-                      {project.category}
-                    </div>
-                    <div className="relative flex h-full flex-col justify-end gap-2 p-6">
-                      <h3 className="text-lg font-bold text-white">{project.title}</h3>
-                      <p className="text-[0.65rem] uppercase tracking-[0.35em] text-white/60">
-                        {project.duration} · {project.year}
+            <div className="relative">
+              <div className="absolute -inset-8 rounded-[3rem] bg-gradient-to-br from-sky-500/20 via-transparent to-fuchsia-500/20 blur-3xl" aria-hidden />
+              <div className="relative overflow-hidden rounded-[2.75rem] border border-white/15 bg-slate-900/60 shadow-[0_40px_160px_rgba(56,189,248,0.25)]">
+                <div className="absolute inset-0 bg-gradient-to-br from-white/10 via-transparent to-white/10 opacity-60" aria-hidden />
+                <div className="relative aspect-[4/5] sm:aspect-[4/5.5]">
+                  {featuredProjects[0]?.thumbnail ? (
+                    <img
+                      src={featuredProjects[0].thumbnail}
+                      alt={featuredProjects[0].title}
+                      className="h-full w-full object-cover"
+                      loading="lazy"
+                    />
+                  ) : (
+                    <div className="flex h-full w-full flex-col items-center justify-center bg-gradient-to-br from-sky-500/30 to-indigo-500/30 text-center">
+                      <p className="text-sm font-semibold uppercase tracking-[0.4em] text-white/70">Showreel</p>
+                      <p className="mt-3 max-w-xs text-xs text-white/70">
+                        Découvrez une sélection de projets cinématiques réalisés entre 2023 et 2025.
                       </p>
                     </div>
-                  </Link>
-                ))}
+                  )}
+                  {featuredProjects[0] && (
+                    <div className="absolute inset-x-0 bottom-0 space-y-2 bg-gradient-to-t from-slate-950/85 via-slate-950/60 to-transparent p-6">
+                      <p className="text-[0.65rem] font-semibold uppercase tracking-[0.45em] text-white/60">
+                        {featuredProjects[0].category} · {featuredProjects[0].year}
+                      </p>
+                      <p className="text-2xl font-semibold leading-tight text-white">{featuredProjects[0].title}</p>
+                      <p className="text-sm text-white/70">{featuredProjects[0].tagline}</p>
+                    </div>
+                  )}
+                </div>
               </div>
             </div>
           </div>
         </header>
 
-        <section className="relative mx-auto max-w-6xl px-6 pb-24">
-          <div
-            className="absolute inset-0 -z-10 blur-3xl"
-            style={{ background: "radial-gradient(circle at 20% 20%, hsl(var(--visual-accent) / 0.18), transparent 60%)" }}
-          />
-          <div className="rounded-[3rem] border border-white/10 bg-white/5 p-10 shadow-[0_0_80px_rgba(59,130,246,0.15)] visual-accent-veil">
-            <div className="flex flex-col items-start gap-6 pb-10 lg:flex-row lg:items-center lg:justify-between">
-              <div>
-                <p className="text-sm uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Méthode intégrée</p>
-                <h2 className="mt-3 text-4xl font-extrabold">
-                  Une chaîne de production orchestrée par IA, DesignOps et équipes de plateau
-                </h2>
+        <section className="grid gap-6 rounded-[3rem] border border-white/10 bg-white/5 p-12 shadow-[0_20px_120px_rgba(236,72,153,0.18)]">
+          <p className="text-xs font-semibold uppercase tracking-[0.5em] text-white/60">Signature</p>
+          <h2 className="text-3xl font-extrabold sm:text-4xl">Une méthode de vidéaste freelance pour vos ambitions de marque</h2>
+          <div className="grid gap-6 sm:grid-cols-3">
+            {creativePrinciples.map((principle) => (
+              <div key={principle.title} className="rounded-[2.5rem] border border-white/10 bg-slate-900/60 p-6">
+                <h3 className="text-xl font-semibold text-white">{principle.title}</h3>
+                <p className="mt-3 text-sm text-white/70">{principle.description}</p>
               </div>
-              <div className="flex gap-3 text-sm text-slate-200/80">
-                {techStack.map((tool) => (
-                  <span
-                    key={tool}
-                    className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-3 py-1"
-                  >
-                    <span className="h-2 w-2 rounded-full bg-cyan-300 visual-accent-dot" /> {tool}
-                  </span>
-                ))}
-              </div>
-            </div>
-
-            <div className="grid gap-6 lg:grid-cols-3">
-              {servicesData.map((service, index) => (
-                <Link
-                  key={service.slug}
-                  to={`/services/${service.slug}`}
-                  className="group relative overflow-hidden rounded-[2rem] border border-white/10 bg-gradient-to-br from-white/10 to-white/5 p-8 shadow-[0_30px_100px_rgba(56,189,248,0.12)] visual-accent-hover-shadow transition-transform duration-500 hover:-translate-y-2"
-                >
-                  <span className="absolute inset-0 translate-y-full bg-gradient-to-t from-cyan-500/30 via-transparent to-transparent visual-accent-gradient transition-transform duration-700 group-hover:translate-y-0 visual-accent-gradient" />
-                  <div className="relative space-y-4">
-                    <span className="inline-flex items-center gap-3 text-sm font-semibold text-cyan-200/80 visual-accent-text">
-                      <span className="text-2xl">0{index + 1}</span> {service.title}
-                    </span>
-                    <p className="text-xl font-bold text-white">{service.subtitle}</p>
-                    <p className="text-sm text-slate-200/80">{service.promise}</p>
-                    <div className="flex flex-wrap gap-2 text-xs text-cyan-100/70 visual-accent-text-strong">
-                      {service.stack.map((tool) => (
-                        <span key={tool} className="rounded-full bg-cyan-500/10 visual-accent-chip px-3 py-1">
-                          {tool}
-                        </span>
-                      ))}
-                    </div>
-                    <p className="text-xs uppercase tracking-[0.3em] text-slate-300/70">Consulter la méthodologie →</p>
-                  </div>
-                </Link>
-              ))}
-            </div>
+            ))}
           </div>
         </section>
 
-        <section className="relative mx-auto max-w-6xl px-6 pb-24">
-          <div className="flex flex-col gap-10 lg:flex-row">
-            <div className="flex-1 space-y-6">
-              <p className="text-sm uppercase tracking-[0.3em] text-indigo-200/70">Réalisations récentes</p>
-              <h2 className="text-4xl font-extrabold leading-tight">
-                Un portefeuille modulable piloté depuis votre tableau de bord
-              </h2>
-              <p className="text-lg text-slate-200/80">
-                Chaque projet est structuré selon les standards de gouvernance employés par Accenture Song ou Wieden+Kennedy : roadmaps dynamiques, assets versionnés et analytics intégrés.
-              </p>
-              <div className="grid gap-4 text-sm text-slate-200/80">
-                <div className="rounded-3xl border border-white/10 bg-white/5 p-5">
-                  <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/60 visual-accent-text">Processus éditorial</p>
-                  <p className="mt-2">Brief, scénario, droits et livrables sont cadrés avec les frameworks RACI et Brand Sprint pour accélérer la validation interne.</p>
+        <section className="space-y-10">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.5em] text-white/60">Réalisations</p>
+              <h2 className="mt-2 text-3xl font-extrabold sm:text-4xl">Projets récents</h2>
+            </div>
+            <Link
+              to="/realisations"
+              className="inline-flex items-center gap-3 rounded-full border border-white/20 px-6 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-white/70 transition-colors hover:text-white"
+            >
+              Voir toutes les réalisations
+            </Link>
+          </div>
+          <div className="grid gap-10 lg:grid-cols-3">
+            {featuredProjects.map((project) => (
+              <article key={project.id} className="group relative overflow-hidden rounded-[2.75rem] border border-white/10 bg-slate-900/60">
+                <div className="relative h-64 overflow-hidden">
+                  {project.thumbnail ? (
+                    <img src={project.thumbnail} alt={project.title} className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105" loading="lazy" />
+                  ) : (
+                    <div className={cn("h-full w-full", project.gradient, "bg-gradient-to-br")}></div>
+                  )}
+                  <div className="absolute inset-0 bg-gradient-to-t from-slate-950/85 via-transparent to-transparent" aria-hidden />
+                  <div className="absolute bottom-4 left-5 flex flex-wrap items-center gap-2 text-[0.65rem] font-semibold uppercase tracking-[0.45em] text-white/70">
+                    <span>{project.category}</span>
+                    <span className="h-1 w-1 rounded-full bg-white/40" aria-hidden />
+                    <span>{project.year}</span>
+                  </div>
                 </div>
-                <div className="rounded-3xl border border-white/10 bg-white/5 p-5">
-                  <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/60 visual-accent-text">Pilotage data</p>
-                  <p className="mt-2">Classement par thématique, scoring IA des performances et bibliothèques audio certifiées garantissent un pilotage MMM-ready.</p>
+                <div className="space-y-4 p-8">
+                  <h3 className="text-2xl font-semibold text-white">{project.title}</h3>
+                  <p className="text-sm text-white/70">{project.description}</p>
+                  <div className="flex flex-wrap gap-2 text-[0.6rem] uppercase tracking-[0.35em] text-white/55">
+                    {project.deliverables.slice(0, 3).map((deliverable) => (
+                      <span key={deliverable}>{deliverable}</span>
+                    ))}
+                  </div>
                 </div>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="grid gap-8 lg:grid-cols-[1.25fr_1fr]">
+          <div className="space-y-8">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.5em] text-white/60">Services</p>
+                <h2 className="mt-2 text-3xl font-extrabold sm:text-4xl">Offres signatures</h2>
               </div>
               <Link
-                to="/portfolio"
-                className="inline-flex items-center gap-3 rounded-full border border-indigo-200/40 bg-indigo-500/20 px-6 py-3 text-sm font-semibold uppercase tracking-[0.25em] text-white shadow-[0_15px_50px_rgba(59,130,246,0.3)] visual-secondary-glow visual-accent-glow"
+                to="/services"
+                className="inline-flex items-center gap-3 rounded-full border border-white/20 px-6 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-white/70 transition-colors hover:text-white"
               >
-                Explorer la galerie complète
+                Explorer tous les services
               </Link>
             </div>
-
-            <div className="flex-1 space-y-6">
-              {portfolioItems.slice(0, 3).map((project, index) => (
-                <article
-                  key={project.id}
-                  className="group relative overflow-hidden rounded-[2.5rem] border border-white/10 bg-gradient-to-br from-white/10 to-white/5 p-6 shadow-[0_25px_90px_rgba(59,130,246,0.12)] visual-accent-hover-shadow transition-all duration-500 hover:-translate-y-2 hover:shadow-[0_35px_120px_rgba(14,165,233,0.2)]"
-                >
-                  <span
-                    className="absolute inset-0 -z-10 opacity-0 transition-opacity duration-700 group-hover:opacity-100"
-                    style={{
-                      background:
-                        "linear-gradient(120deg, hsl(var(--visual-accent) / 0.25), hsl(var(--visual-secondary) / 0.2))",
-                    }}
-                  />
-                  <div className="relative flex flex-col gap-4">
-                    <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-slate-200/70">
-                      <span>Projet 0{index + 1}</span>
-                      <span>{project.category}</span>
-                    </div>
-                    <h3 className="text-2xl font-bold text-white">{project.title}</h3>
-                    <p className="text-sm text-slate-200/80">{project.description}</p>
-                    <div className="grid gap-3 text-xs text-cyan-100/80 visual-accent-text-strong sm:grid-cols-3">
-                      <div className="rounded-2xl bg-white/5 p-3 text-center">{project.duration}</div>
-                      <div className="rounded-2xl bg-white/5 p-3 text-center">{project.year}</div>
-                      <div className="rounded-2xl bg-white/5 p-3 text-center">{project.socialStack[0]}</div>
-                    </div>
-                    <img src={project.thumbnail} alt={project.title} className="h-56 w-full rounded-[2rem] object-cover" />
+            <div className="grid gap-8 lg:grid-cols-3">
+              {highlightServices.map((service) => (
+                <article key={service.slug} className="flex flex-col gap-6 rounded-[2.5rem] border border-white/10 bg-slate-900/60 p-6 shadow-[0_18px_80px_rgba(59,130,246,0.18)]">
+                  <div className="space-y-2">
+                    <p className="text-[0.65rem] font-semibold uppercase tracking-[0.45em] text-white/60">{service.slug.replaceAll("-", " ")}</p>
+                    <h3 className="text-2xl font-semibold text-white">{service.title}</h3>
+                    <p className="text-sm text-white/70">{service.subtitle}</p>
                   </div>
+                  <p className="text-sm text-white/70">{service.promise}</p>
+                  <div className="flex flex-wrap gap-2 text-[0.6rem] uppercase tracking-[0.35em] text-white/55">
+                    {service.stack.slice(0, 4).map((tool) => (
+                      <span key={tool}>{tool}</span>
+                    ))}
+                  </div>
+                  <Link
+                    to={`/services/${service.slug}`}
+                    className="inline-flex items-center gap-3 rounded-full border border-white/20 px-5 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.4em] text-white/70 transition-colors hover:text-white"
+                  >
+                    Voir le détail
+                  </Link>
                 </article>
               ))}
             </div>
           </div>
+          <aside className="flex h-full flex-col justify-between gap-6 rounded-[2.75rem] border border-white/10 bg-gradient-to-br from-sky-500/10 via-slate-900/60 to-indigo-500/10 p-8">
+            <div className="space-y-4">
+              <p className="text-xs font-semibold uppercase tracking-[0.45em] text-white/60">Technologie & craft</p>
+              <h2 className="text-3xl font-extrabold text-white">Stack 2025</h2>
+              <p className="text-sm text-white/70">
+                Chaque projet bénéficie d'un setup modulable. Voici les briques que j'assemble selon vos enjeux.
+              </p>
+            </div>
+            <ul className="space-y-4 text-sm text-white/75">
+              {stackHighlights.map((item) => (
+                <li key={item.title} className="rounded-3xl border border-white/10 bg-slate-900/60 p-5">
+                  <p className="text-base font-semibold text-white">{item.title}</p>
+                  <p className="mt-2 text-sm text-white/70">{item.description}</p>
+                </li>
+              ))}
+            </ul>
+            <Link
+              to="/playground"
+              className="inline-flex items-center justify-center gap-3 rounded-full border border-white/20 px-6 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-white/70 transition-colors hover:text-white"
+            >
+              Voir les coulisses & workflows
+            </Link>
+          </aside>
         </section>
 
-        <section className="relative mx-auto max-w-6xl px-6 pb-24" id="contact">
-          <div className="rounded-[3rem] border border-white/10 bg-gradient-to-br from-white/10 to-white/5 p-10 shadow-[0_25px_100px_rgba(8,145,178,0.18)]">
-            <div className="grid gap-10 lg:grid-cols-[1.2fr_1fr]">
-              <div className="space-y-6">
-                <p className="text-sm uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Onboarding express</p>
-                <h2 className="text-4xl font-extrabold leading-tight">
-                  Kick-off 360° en 90 secondes avec nos stratèges et producteurs.
-                </h2>
-                <div className="grid gap-4 text-sm text-slate-200/80">
-                  <div className="rounded-3xl border border-white/10 bg-white/5 p-5">
-                    <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/60 visual-accent-text">Analyse initiale</p>
-                    <p className="mt-2">Objectifs, audiences, canaux et KPI sont captés dans un canvas Miro pour préparer une réponse opérationnelle.</p>
-                  </div>
-                  <div className="rounded-3xl border border-white/10 bg-white/5 p-5">
-                    <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/60 visual-accent-text">Coordination interne</p>
-                    <p className="mt-2">Le brief est synchronisé avec le pôle création, la cellule IA et la production plateau via Notion et Slack Connect pour une réponse argumentée et chiffrée.</p>
-                  </div>
-                </div>
-              </div>
+        <section className="grid gap-10 rounded-[3rem] border border-white/10 bg-white/5 p-12">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.5em] text-white/60">Retours clients</p>
+              <h2 className="mt-2 text-3xl font-extrabold sm:text-4xl">Ils m'ont confié leurs histoires</h2>
+            </div>
+            <Link
+              to="/a-propos"
+              className="inline-flex items-center gap-3 rounded-full border border-white/20 px-6 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-white/70 transition-colors hover:text-white"
+            >
+              En savoir plus sur Alex
+            </Link>
+          </div>
+          <div className="grid gap-8 lg:grid-cols-3">
+            {testimonials.map((testimonial) => (
+              <blockquote key={testimonial.author} className="flex h-full flex-col gap-4 rounded-[2.5rem] border border-white/10 bg-slate-900/60 p-8">
+                <p className="text-base text-white/80">“{testimonial.quote}”</p>
+                <footer className="space-y-1 text-sm text-white/60">
+                  <p className="font-semibold text-white">{testimonial.author}</p>
+                  <p>{testimonial.role}</p>
+                </footer>
+              </blockquote>
+            ))}
+          </div>
+        </section>
 
-              <form
-                className="space-y-4"
-                onSubmit={(event) => {
-                  event.preventDefault();
-                  recordContactRequest(form);
-                  setContactSent(true);
-                  setForm({ name: "", email: "", projectSpark: "", urgency: "hier" });
-                }}
-              >
-                <div>
-                  <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Nom / pseudo</label>
+        <section className="grid gap-12 rounded-[3rem] border border-white/10 bg-gradient-to-br from-slate-900/70 via-slate-950 to-indigo-950 p-12">
+          <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
+            <div className="space-y-4">
+              <p className="text-xs font-semibold uppercase tracking-[0.45em] text-white/60">Préparez votre projet</p>
+              <h2 className="text-3xl font-extrabold text-white sm:text-4xl">Brief express</h2>
+              <p className="max-w-xl text-sm text-white/70">
+                Dites-moi ce qui vous anime, je vous propose un cadrage et une dispo de tournage en moins de 24 heures.
+              </p>
+              <div className="rounded-[2.5rem] border border-white/10 bg-slate-900/60 p-6 text-sm text-white/70">
+                <p className="text-xs uppercase tracking-[0.35em] text-white/60">Prochaines disponibilités</p>
+                <ul className="mt-4 space-y-2">
+                  <li>• Semaine du 17 février : tournage corporate</li>
+                  <li>• 3-4 mars : aftermovie & événementiel</li>
+                  <li>• Slots motion design ouverts sur avril</li>
+                </ul>
+              </div>
+            </div>
+            <form className="space-y-4" onSubmit={onSubmit}>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <label className="flex flex-col gap-2 text-sm text-white/70">
+                  Nom
                   <input
-                    required
+                    type="text"
                     value={form.name}
-                    onChange={(event) => setForm((prev) => ({ ...prev, name: event.target.value }))}
-                    className="mt-2 w-full rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-white placeholder:text-slate-300/60 focus:border-cyan-400 visual-accent-border focus:outline-none"
-                    placeholder="Nom et prénom"
+                    onChange={(event) => setForm((current) => ({ ...current, name: event.target.value }))}
+                    className="rounded-2xl border border-white/20 bg-white/10 px-4 py-3 text-sm text-white placeholder:text-white/50 focus:border-sky-400 focus:outline-none"
+                    placeholder="Prénom Nom"
+                    required
                   />
-                </div>
-                <div>
-                  <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Email</label>
+                </label>
+                <label className="flex flex-col gap-2 text-sm text-white/70">
+                  Email
                   <input
                     type="email"
-                    required
                     value={form.email}
-                    onChange={(event) => setForm((prev) => ({ ...prev, email: event.target.value }))}
-                    className="mt-2 w-full rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-white placeholder:text-slate-300/60 focus:border-cyan-400 visual-accent-border focus:outline-none"
-                    placeholder="vous@futurebrand.com"
-                  />
-                </div>
-                <div>
-                  <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Étincelle</label>
-                  <textarea
+                    onChange={(event) => setForm((current) => ({ ...current, email: event.target.value }))}
+                    className="rounded-2xl border border-white/20 bg-white/10 px-4 py-3 text-sm text-white placeholder:text-white/50 focus:border-sky-400 focus:outline-none"
+                    placeholder="vous@entreprise.com"
                     required
-                    value={form.projectSpark}
-                    onChange={(event) => setForm((prev) => ({ ...prev, projectSpark: event.target.value }))}
-                    rows={4}
-                    className="mt-2 w-full rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-white placeholder:text-slate-300/60 focus:border-cyan-400 visual-accent-border focus:outline-none"
-                    placeholder="Décrivez le contexte, les objectifs et les livrables attendus"
                   />
+                </label>
+              </div>
+              <label className="flex flex-col gap-2 text-sm text-white/70">
+                Projet
+                <textarea
+                  value={form.projectSpark}
+                  onChange={(event) => setForm((current) => ({ ...current, projectSpark: event.target.value }))}
+                  className="min-h-[120px] rounded-2xl border border-white/20 bg-white/10 px-4 py-3 text-sm text-white placeholder:text-white/50 focus:border-sky-400 focus:outline-none"
+                  placeholder="Lancement film de marque, aftermovie, série social..."
+                  required
+                />
+              </label>
+              <fieldset className="space-y-3 text-sm text-white/70">
+                <legend className="text-xs uppercase tracking-[0.35em] text-white/60">Urgence</legend>
+                <div className="grid gap-2 sm:grid-cols-3">
+                  {urgencyOptions.map((option) => {
+                    const isActive = form.urgency === option.value;
+                    return (
+                      <label
+                        key={option.value}
+                        className={cn(
+                          "flex cursor-pointer items-center justify-center gap-2 rounded-2xl border px-4 py-3 text-center text-xs font-semibold uppercase tracking-[0.35em] transition-colors",
+                          isActive ? "border-sky-400/60 bg-sky-500/20 text-white" : "border-white/20 bg-white/10 text-white/70"
+                        )}
+                      >
+                        <input
+                          type="radio"
+                          name="urgency"
+                          value={option.value}
+                          checked={isActive}
+                          onChange={(event) => setForm((current) => ({ ...current, urgency: event.target.value }))}
+                          className="hidden"
+                        />
+                        {option.label}
+                      </label>
+                    );
+                  })}
                 </div>
-                <div>
-                  <label className="text-xs uppercase tracking-[0.3em] text-slate-200/70">Urgence</label>
-                  <select
-                    value={form.urgency}
-                    onChange={(event) => setForm((prev) => ({ ...prev, urgency: event.target.value as typeof form.urgency }))}
-                    className="mt-2 w-full rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-white focus:border-cyan-400 visual-accent-border focus:outline-none"
-                  >
-                    <option value="hier">Projet urgent</option>
-                    <option value="cette-semaine">Démarrage sous 7 jours</option>
-                    <option value="quand-c-est-parfait">Planifié</option>
-                  </select>
-                </div>
-                <button
-                  type="submit"
-                  className="group relative w-full overflow-hidden rounded-full border border-cyan-200/40 visual-accent-border bg-cyan-500/20 visual-accent-bg px-6 py-3 text-sm font-bold uppercase tracking-[0.3em] text-white"
-                >
-                  <span className="relative z-10">Envoyer ma demande</span>
-                  <span className="absolute inset-0 translate-x-[-120%] bg-gradient-to-r from-cyan-400 via-sky-300 to-indigo-400 visual-accent-gradient transition-transform duration-700 group-hover:translate-x-0 visual-accent-gradient" />
-                </button>
-                {contactSent && (
-                  <p className="rounded-2xl border border-cyan-200/30 visual-accent-border bg-cyan-500/10 visual-accent-chip px-4 py-3 text-sm text-cyan-100 visual-accent-text-strong">
-                    Merci pour votre message. Un membre de l'équipe Studio VBG revient vers vous sous 2 heures ouvrées.
-                  </p>
-                )}
-              </form>
-            </div>
+              </fieldset>
+              <button
+                type="submit"
+                className="inline-flex w-full items-center justify-center gap-3 rounded-full bg-gradient-to-r from-sky-500 via-indigo-500 to-fuchsia-500 px-8 py-4 text-sm font-bold uppercase tracking-[0.35em] text-white shadow-[0_18px_80px_rgba(59,130,246,0.4)] disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={formState !== "idle" && formState !== "sent"}
+              >
+                {formState === "sending" ? "Envoi..." : formState === "sent" ? "Brief reçu !" : "Envoyer le brief"}
+              </button>
+            </form>
           </div>
         </section>
 
-        <footer className="mx-auto max-w-6xl px-6 pb-16">
-          <div className="rounded-[2.5rem] border border-white/10 bg-white/5 p-10 text-sm text-slate-200/70">
-            <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
-              <div>
-                <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Studio VBG</p>
-                <p className="mt-2 text-lg text-white">Agence de production, captation vidéo, création de contenus réseaux sociaux.</p>
-              </div>
-              <div className="flex gap-4 text-xs uppercase tracking-[0.3em] text-slate-300/80">
-                <Link to="/process" className="hover:text-white">Méthode</Link>
-                <Link to="/services" className="hover:text-white">Services</Link>
-                <Link to="/dashboard" className="hover:text-white">Dashboard</Link>
-              </div>
-              <div className="text-xs text-slate-300/80">
-                © {new Date().getFullYear()} Studio VBG · Pipeline propulsé par l'IA et une gestion de projet rigoureuse.
-              </div>
-            </div>
+        <section className="rounded-[3rem] border border-white/10 bg-white/5 p-12 text-center">
+          <h2 className="text-3xl font-extrabold text-white sm:text-4xl">Prêt à écrire la prochaine scène ?</h2>
+          <p className="mx-auto mt-4 max-w-2xl text-sm text-white/70">
+            Parlons de vos ambitions vidéo : je vous envoie un plan d'action, un calendrier et un devis précis sous 24 h.
+          </p>
+          <div className="mt-8 flex flex-wrap justify-center gap-4">
+            <Link
+              to="/quote"
+              className="rounded-full border border-sky-300/40 bg-sky-500/20 px-6 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-white"
+            >
+              Demander un devis
+            </Link>
+            <Link
+              to="/contact"
+              className="rounded-full border border-white/30 bg-white/10 px-6 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-white/70 hover:text-white"
+            >
+              M'écrire directement
+            </Link>
           </div>
-        </footer>
-      </div>
+        </section>
+      </main>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- refresh the home experience with a videographer-focused hero, featured work, services, testimonials and an updated contact flow
- expand the service catalogue to six SEO-ready offers matching the new brand positioning and ribbon messaging
- add dedicated About and Contact pages plus route aliases for réalisations and supporting navigation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d611cf4508832894dd760ef60967c5