### PR TITLE
Ensure mobile navigation accordion items use unique values

### DIFF
--- a/src/components/header/HeaderRoot.tsx
+++ b/src/components/header/HeaderRoot.tsx
@@ -275,7 +275,7 @@ export function HeaderRoot() {
 
                       return (
                         <Accordion key={item.label} type="single" collapsible className="rounded-2xl border border-white/10 bg-white/5">
-                          <AccordionItem value="open">
+                          <AccordionItem value={item.href ?? item.label}>
                             <AccordionTrigger className="px-4 py-3 text-left text-sm uppercase tracking-[0.3em] text-white">
                               {item.label}
                             </AccordionTrigger>


### PR DESCRIPTION
## Summary
- update the mobile navigation accordion to derive its item value from the destination link for uniqueness

## Testing
- npm run lint *(fails: existing parsing error in src/App.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d6416493c883288cc1630430d9720d