### PR TITLE
feat: add translucent navigation menu trigger variant

### DIFF
--- a/src/components/header/HeaderRoot.tsx
+++ b/src/components/header/HeaderRoot.tsx
@@ -404,7 +404,10 @@ export function HeaderRoot() {
                 if (item.children?.length) {
                   return (
                     <NavigationMenuItem key={item.label}>
-                      <NavigationMenuTrigger className="text-sm font-medium uppercase tracking-[0.3em] text-white/70 hover:text-white">
+                      <NavigationMenuTrigger
+                        variant="translucent"
+                        className="text-sm font-medium uppercase tracking-[0.3em] text-white/70 hover:text-white focus-visible:text-white"
+                      >
                         {item.label}
                       </NavigationMenuTrigger>
                       <NavigationMenuContent className="mt-2 w-80 rounded-3xl border border-white/10 bg-slate-950/95 p-3 text-white shadow-xl">
@@ -436,7 +439,10 @@ export function HeaderRoot() {
 
                 return (
                   <NavigationMenuItem key={item.label}>
-                    <NavigationMenuTrigger className="text-sm font-medium uppercase tracking-[0.3em] text-white/70 hover:text-white">
+                    <NavigationMenuTrigger
+                      variant="translucent"
+                      className="text-sm font-medium uppercase tracking-[0.3em] text-white/70 hover:text-white focus-visible:text-white"
+                    >
                       {item.label}
                     </NavigationMenuTrigger>
                     <NavigationMenuContent className="mt-3 w-[720px] rounded-[2rem] border border-white/10 bg-slate-950/95 p-6 text-white shadow-2xl">

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu";
-import { cva } from "class-variance-authority";
+import { cva, type VariantProps } from "class-variance-authority";
 import { ChevronDown } from "lucide-react";
 
 import { cn } from "@/lib/utils";
@@ -35,16 +35,30 @@ NavigationMenuList.displayName = NavigationMenuPrimitive.List.displayName;
 const NavigationMenuItem = NavigationMenuPrimitive.Item;
 
 const navigationMenuTriggerStyle = cva(
-  "group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-accent/50 data-[state=open]:bg-accent/50",
+  "group inline-flex h-10 w-max items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors focus:outline-none focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-background hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground data-[active]:bg-accent/50 data-[state=open]:bg-accent/50",
+        translucent:
+          "border border-black/10 bg-transparent hover:bg-black/5 focus-visible:bg-black/5 data-[state=open]:bg-black/5 focus-visible:ring-2 focus-visible:ring-black/20 focus-visible:ring-offset-0 dark:border-white/10 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:data-[state=open]:bg-white/10 dark:focus-visible:ring-white/70",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
 );
 
 const NavigationMenuTrigger = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Trigger>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Trigger> &
+    VariantProps<typeof navigationMenuTriggerStyle>
+>(({ className, children, variant, ...props }, ref) => (
   <NavigationMenuPrimitive.Trigger
     ref={ref}
-    className={cn(navigationMenuTriggerStyle(), "group", className)}
+    className={cn(navigationMenuTriggerStyle({ variant }), className)}
     {...props}
   >
     {children}{" "}


### PR DESCRIPTION
## Summary
- add a translucent variant to the navigation menu trigger to support transparent backgrounds while keeping default styles intact
- switch the header navigation triggers to the translucent styling and ensure focus-visible text contrast remains accessible

## Testing
- npm run lint *(fails: existing syntax error in src/App.tsx unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d643137af08328ad064ca91bfaee14