### PR TITLE
Align services architecture with new site structure

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,31 @@
 <!doctype html>
-<html lang="en">
+<html lang="fr">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>studio-gitup-link</title>
     <meta name="description" content="Lovable Generated Project" />
     <meta name="author" content="Lovable" />
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="preload"
+      as="style"
+      href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&family=Newsreader:opsz,wght@6..72,400..800&display=swap"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&family=Newsreader:opsz,wght@6..72,400..800&display=swap"
+      media="print"
+      onload="this.media='all'"
+    />
+    <noscript>
+      <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..900&family=Newsreader:opsz,wght@6..72,400..800&display=swap"
+      />
+    </noscript>
 
     <meta property="og:title" content="studio-gitup-link" />
     <meta property="og:description" content="Lovable Generated Project" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,7 +96,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -159,6 +158,22 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.25.9",
@@ -1053,7 +1068,6 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -1071,7 +1085,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
       "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
@@ -1086,7 +1099,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1096,7 +1108,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1106,14 +1117,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1124,7 +1133,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -1138,7 +1146,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -1148,7 +1155,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -1162,7 +1168,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -3118,6 +3123,27 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.8.0.tgz",
@@ -3172,6 +3198,14 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.2",
@@ -3286,14 +3320,14 @@
       "version": "15.7.13",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
       "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -3304,7 +3338,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -3760,7 +3794,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
       "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3773,7 +3806,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3789,14 +3821,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -3810,7 +3840,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -3894,7 +3923,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/bidi-js": {
@@ -3911,7 +3939,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3935,7 +3962,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -4001,7 +4027,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4076,7 +4101,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -4101,7 +4125,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -4150,7 +4173,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4163,14 +4185,12 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4187,7 +4207,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -4222,7 +4241,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -4502,15 +4520,21 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -4526,7 +4550,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
@@ -4568,7 +4591,6 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/entities": {
@@ -4877,7 +4899,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
       "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -4894,7 +4915,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -4921,7 +4941,6 @@
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
       "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -4944,7 +4963,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -4995,7 +5013,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
       "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.0",
@@ -5053,7 +5070,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5068,7 +5084,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5087,7 +5102,6 @@
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
       "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -5108,7 +5122,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -5121,7 +5134,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -5131,7 +5143,6 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -5177,7 +5188,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -5310,7 +5320,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -5323,7 +5332,6 @@
       "version": "2.15.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
       "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -5339,7 +5347,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5349,7 +5356,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5359,7 +5365,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -5372,7 +5377,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -5389,14 +5393,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -5412,7 +5414,6 @@
       "version": "1.21.6",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
       "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -5563,7 +5564,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -5576,7 +5576,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -6093,7 +6092,6 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/lucide-react": {
@@ -6102,6 +6100,17 @@
       "integrity": "sha512-NTL7EbAao9IFtuSivSZgrAh4fZd09Lr+6MTkqIxuHaH2nnYiYIzXPo06cOxHg9wKLdj6LL8TByG4qpePqwgx/g==",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -6125,7 +6134,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -6135,7 +6143,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -6172,7 +6179,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -6204,7 +6210,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -6216,7 +6221,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6259,7 +6263,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6288,7 +6291,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -6348,7 +6350,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/parent-module": {
@@ -6391,7 +6392,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6401,14 +6401,12 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -6442,14 +6440,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -6462,7 +6458,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6472,7 +6467,6 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
       "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -6482,7 +6476,6 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -6511,7 +6504,6 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -6529,7 +6521,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
       "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "camelcase-css": "^2.0.1"
@@ -6549,7 +6540,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
       "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -6585,7 +6575,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -6611,7 +6600,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -6625,7 +6613,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -6637,6 +6624,55 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -6669,7 +6705,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6893,7 +6928,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -6903,7 +6937,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -6972,7 +7005,6 @@
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
       "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.13.0",
@@ -7000,7 +7032,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -7054,7 +7085,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7120,7 +7150,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -7133,7 +7162,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7150,7 +7178,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -7173,7 +7200,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -7197,7 +7223,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -7216,7 +7241,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -7231,7 +7255,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7241,14 +7264,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -7261,7 +7282,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -7278,7 +7298,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -7291,7 +7310,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7347,7 +7365,6 @@
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
       "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -7383,7 +7400,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7413,7 +7429,6 @@
       "version": "3.4.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -7460,7 +7475,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -7470,7 +7484,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -7601,7 +7614,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -7646,7 +7658,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tslib": {
@@ -7809,7 +7820,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/uuid": {
@@ -8085,7 +8095,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -8128,7 +8137,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -8147,7 +8155,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -8165,7 +8172,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8175,14 +8181,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -8197,7 +8201,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -8210,7 +8213,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -8261,7 +8263,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
       "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,8 +57,9 @@ const App = () => (
               <Route path="/playground" element={<Playground />} />
 
               {/* Portfolio + alias SEO */}
-              <Route path="/portfolio" element={<Navigate to="/realisations" replace />} />
-              <Route path="/realisations" element={<Portfolio />} />
+              <Route path="/portfolio" element={<Portfolio />} />
+              <Route path="/portfolio/:category" element={<Portfolio />} />
+              <Route path="/realisations" element={<Navigate to="/portfolio" replace />} />
               <Route path="/realisations/:category" element={<Portfolio />} />
 
               {/* Process & Devis */}

--- a/src/components/footer/SiteFooter.tsx
+++ b/src/components/footer/SiteFooter.tsx
@@ -53,11 +53,11 @@ export function SiteFooter() {
 
         <div className="space-y-3 text-sm text-white/70">
           <h3 className="text-xs font-semibold uppercase tracking-[0.4em] text-white/50">Réalisations</h3>
-          <Link to="/realisations" className="block transition hover:text-white">
+          <Link to="/portfolio" className="block transition hover:text-white">
             Index réalisations
           </Link>
           {CATEGORIES.map((category) => (
-            <Link key={category.slug} to={`/realisations/${category.slug}`} className="block transition hover:text-white">
+            <Link key={category.slug} to={`/portfolio/${category.slug}`} className="block transition hover:text-white">
               {category.label}
             </Link>
           ))}

--- a/src/components/header/HeaderRoot.tsx
+++ b/src/components/header/HeaderRoot.tsx
@@ -1,6 +1,16 @@
-import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
 import { Link, NavLink, useLocation, useNavigate } from "react-router-dom";
 import { ArrowUpRight, Menu, MoonStar, Search, SunMedium } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+
 import { Button } from "@/components/ui/button";
 import {
   CommandDialog,
@@ -35,45 +45,58 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
-import { CTA, CATEGORIES, MAIN_NAV, type CategorySlug } from "./nav.config";
-import { AnimatePresence, motion } from "framer-motion";
 
-const progressStyles =
-  "pointer-events-none fixed inset-x-0 top-0 z-[60] h-0.5 overflow-hidden";
+import { CTA, CATEGORIES, MAIN_NAV } from "./nav.config";
 
-const progressTransition = {
+type Theme = "light" | "dark";
+type Language = "FR" | "EN";
+
+const easing = [0.22, 1, 0.36, 1] as const;
+
+const indicatorTransition = {
   type: "spring",
-  stiffness: 210,
-  damping: 32,
-  mass: 0.8,
+  stiffness: 420,
+  damping: 36,
+  mass: 0.65,
 };
 
-const navUnderlineTransition = {
-  type: "spring",
-  stiffness: 360,
-  damping: 32,
-};
+function useScrollProgress() {
+  const [progress, setProgress] = useState(0);
 
-const subnavHighlightTransition = {
-  type: "spring",
-  stiffness: 320,
-  damping: 34,
-};
+  useEffect(() => {
+    const update = () => {
+      if (typeof document === "undefined") return;
+      const { scrollTop, scrollHeight, clientHeight } =
+        document.documentElement;
+      const max = Math.max(scrollHeight - clientHeight, 1);
+      setProgress(Math.min(scrollTop / max, 1));
+    };
 
-export function HeaderRoot() {
-  const location = useLocation();
-  const navigate = useNavigate();
+    update();
+    window.addEventListener("scroll", update, { passive: true });
+    return () => window.removeEventListener("scroll", update);
+  }, []);
 
-  const [mobileOpen, setMobileOpen] = useState(false);
-  const [commandOpen, setCommandOpen] = useState(false);
+  return progress;
+}
 
-  const [language, setLanguage] = useState<"FR" | "EN">(() => {
+function useLanguage(): [Language, Dispatch<SetStateAction<Language>>] {
+  const [language, setLanguage] = useState<Language>(() => {
     if (typeof window === "undefined") return "FR";
     const stored = window.localStorage.getItem("studio-lang");
     return stored === "EN" ? "EN" : "FR";
   });
 
-  const [theme, setTheme] = useState<"light" | "dark">(() => {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem("studio-lang", language);
+  }, [language]);
+
+  return [language, setLanguage];
+}
+
+function useTheme(): [Theme, Dispatch<SetStateAction<Theme>>] {
+  const [theme, setTheme] = useState<Theme>(() => {
     if (typeof window === "undefined") return "dark";
     const stored = window.localStorage.getItem("studio-theme");
     if (stored === "light" || stored === "dark") return stored;
@@ -83,26 +106,27 @@ export function HeaderRoot() {
     return prefersDark ? "dark" : "light";
   });
 
-  const [scrollProgress, setScrollProgress] = useState(0);
-  const [navReady, setNavReady] = useState(false);
-
-  const applyTheme = useCallback((value: "light" | "dark") => {
+  useEffect(() => {
     if (typeof document === "undefined") return;
-    document.documentElement.classList.toggle("dark", value === "dark");
-    document.documentElement.style.colorScheme = value;
-  }, []);
+    document.documentElement.classList.toggle("dark", theme === "dark");
+    document.documentElement.style.colorScheme = theme;
+    window.localStorage.setItem("studio-theme", theme);
+  }, [theme]);
 
-  useEffect(() => {
-    applyTheme(theme);
-    if (typeof window !== "undefined") {
-      window.localStorage.setItem("studio-theme", theme);
-    }
-  }, [applyTheme, theme]);
+  return [theme, setTheme];
+}
 
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    window.localStorage.setItem("studio-lang", language);
-  }, [language]);
+export function HeaderRoot() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const prefersReducedMotion = useReducedMotion();
+
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const [commandOpen, setCommandOpen] = useState(false);
+  const [language, setLanguage] = useLanguage();
+  const [theme, setTheme] = useTheme();
+
+  const scrollProgress = useScrollProgress();
 
   useEffect(() => {
     const handler = (event: KeyboardEvent) => {
@@ -111,140 +135,114 @@ export function HeaderRoot() {
         setCommandOpen(true);
       }
     };
+
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
   }, []);
-
-  useEffect(() => {
-    const updateProgress = () => {
-      if (typeof document === "undefined") return;
-      const { scrollTop, scrollHeight, clientHeight } =
-        document.documentElement;
-      const max = Math.max(scrollHeight - clientHeight, 1);
-      setScrollProgress(Math.min(scrollTop / max, 1));
-    };
-    updateProgress();
-    window.addEventListener("scroll", updateProgress, { passive: true });
-    return () => window.removeEventListener("scroll", updateProgress);
-  }, []);
-
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      setNavReady(true);
-      return;
-    }
-    const id = window.requestAnimationFrame(() => setNavReady(true));
-    return () => window.cancelAnimationFrame(id);
-  }, []);
-
-  const toggleTheme = useCallback(
-    () => setTheme((current) => (current === "dark" ? "light" : "dark")),
-    []
-  );
-  const toggleLanguage = useCallback(
-    () => setLanguage((current) => (current === "FR" ? "EN" : "FR")),
-    []
-  );
 
   const commandGroups = useMemo(() => {
     const primary = MAIN_NAV.map((item) => ({
       label: item.label,
       href: item.href,
     }));
+
     const services = CATEGORIES.map((category) => ({
       label: `Service · ${category.label}`,
       href: `/services/${category.slug}`,
     }));
+
     const works = CATEGORIES.map((category) => ({
       label: `Réalisations · ${category.label}`,
-      href: `/realisations/${category.slug}`,
+      href: `/portfolio/${category.slug}`,
     }));
+
     return { primary, services, works };
   }, []);
 
-  const serviceSlugFromPath =
-    location.pathname.match(/^\/services\/(?<slug>[^/]+)/)?.groups?.slug;
-  const serviceSlugFromQuery = new URLSearchParams(location.search).get(
-    "service"
-  );
+  const ctaLabel = CTA.label;
+  const ctaHref = CTA.href;
 
-  const activeService = useMemo(() => {
-    const preferred = (serviceSlugFromPath ||
-      serviceSlugFromQuery) as CategorySlug | null;
-    return CATEGORIES.find((category) => category.slug === preferred);
-  }, [serviceSlugFromPath, serviceSlugFromQuery]);
-
-  const ctaLabel = activeService ? `Devis ${activeService.label}` : CTA.label;
-  const ctaHref = activeService
-    ? `/contact?service=${activeService.slug}`
-    : CTA.href;
-
-  const isRealisations = location.pathname.startsWith("/realisations");
+  const isPortfolio = location.pathname.startsWith("/portfolio");
   const isServices = location.pathname.startsWith("/services");
 
   const subNavItems = useMemo(() => {
-    if (!isRealisations && !isServices)
-      return [] as { label: string; href: string }[];
-    const base = isRealisations ? "/realisations" : "/services";
+    if (!isPortfolio && !isServices) return [] as { label: string; href: string }[];
+    const base = isPortfolio ? "/portfolio" : "/services";
     return CATEGORIES.map((category) => ({
       label: category.label,
       href: `${base}/${category.slug}`,
     }));
-  }, [isRealisations, isServices]);
+  }, [isPortfolio, isServices]);
 
   const activeSubnavSlug =
     location.pathname.match(
-      /^\/(?:services|realisations)\/(?<slug>[^/]+)/
+      /^\/(?:services|portfolio)\/(?<slug>[^/]+)/,
     )?.groups?.slug ?? "";
+
+  const dropdownMotion = {
+    initial: {
+      opacity: 0,
+      y: prefersReducedMotion ? 0 : 8,
+      scale: prefersReducedMotion ? 1 : 0.98,
+    },
+    animate: {
+      opacity: 1,
+      y: 0,
+      scale: 1,
+      transition: { duration: 0.24, ease: easing },
+    },
+    exit: {
+      opacity: 0,
+      y: prefersReducedMotion ? 0 : 4,
+      scale: prefersReducedMotion ? 1 : 0.98,
+      transition: { duration: 0.18, ease: easing },
+    },
+  };
+
+  const toggleTheme = useCallback(() => {
+    setTheme((current) => (current === "dark" ? "light" : "dark"));
+  }, [setTheme]);
+
+  const toggleLanguage = useCallback(() => {
+    setLanguage((current) => (current === "FR" ? "EN" : "FR"));
+  }, [setLanguage]);
+
+  const handleCommandSelect = useCallback(
+    (value: string) => {
+      setCommandOpen(false);
+      navigate(value);
+    },
+    [navigate],
+  );
 
   return (
     <Fragment>
-      {/* Top progress bar */}
-      <span className={progressStyles} aria-hidden>
+      <span
+        aria-hidden
+        className="pointer-events-none fixed inset-x-0 top-0 z-[60] h-0.5 bg-transparent"
+      >
         <motion.span
-          className="block h-full w-full origin-left rounded-full bg-gradient-to-r from-cyan-400 via-fuchsia-400 to-violet-500"
+          className="block h-full w-full origin-left rounded-full bg-gradient-to-r from-cyan-400 via-sky-400 to-violet-500"
           initial={false}
           animate={{ scaleX: Math.max(scrollProgress, 0.001) }}
-          transition={progressTransition}
+          transition={{
+            type: "spring",
+            stiffness: 200,
+            damping: 32,
+            mass: 0.7,
+          }}
           style={{ transformOrigin: "left" }}
         />
       </span>
 
-      <header className="relative sticky top-0 z-50 overflow-hidden border-b border-white/10 bg-slate-950/80 shadow-[0_0_35px_rgba(15,23,42,0.65)] backdrop-blur-xl">
-        <motion.div
-          aria-hidden
-          className="pointer-events-none absolute inset-0"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ duration: 0.6, ease: [0.22, 1, 0.36, 1] }}
-        >
-          <motion.div
-            className="absolute -inset-x-32 -top-24 h-48 bg-gradient-to-r from-cyan-400/30 via-fuchsia-400/15 to-transparent blur-3xl"
-            animate={{ x: [0, 60, -40, 0] }}
-            transition={{
-              repeat: Infinity,
-              repeatType: "mirror",
-              duration: 18,
-              ease: "linear",
-            }}
-          />
-          <motion.div
-            className="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-white/20 to-transparent"
-            initial={{ scaleX: 0 }}
-            animate={{ scaleX: 1 }}
-            transition={{ duration: 1.1, ease: [0.22, 1, 0.36, 1] }}
-          />
-        </motion.div>
-
-        <div className="relative z-10 mx-auto flex max-w-6xl items-center gap-3 px-4 py-3 sm:px-6">
-          {/* Left: mobile menu + brand */}
-          <div className="flex items-center gap-3">
-            {/* Mobile drawer */}
+      <header className="sticky top-0 z-50 border-b border-white/10 bg-slate-950/75 backdrop-blur-md">
+        <div className="mx-auto flex max-w-6xl items-center gap-3 px-4 py-3 sm:px-6">
+          <div className="flex flex-1 items-center gap-3">
             <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
               <SheetTrigger asChild>
                 <button
                   type="button"
-                  className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 text-white transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/40 lg:hidden"
+                  className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/15 text-white transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/50 lg:hidden"
                   aria-label="Ouvrir la navigation"
                 >
                   <Menu className="h-5 w-5" />
@@ -252,13 +250,13 @@ export function HeaderRoot() {
               </SheetTrigger>
               <SheetContent
                 side="left"
-                className="w-full max-w-sm border-white/10 bg-slate-950/95 p-0 text-white"
+                className="w-full max-w-sm border-white/10 bg-slate-950/90 p-0 text-white"
               >
                 <SheetHeader className="space-y-2 border-b border-white/10 px-6 pb-4 pt-6 text-left">
-                  <SheetTitle className="flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.35em] text-white/60">
+                  <SheetTitle className="text-xs font-semibold uppercase tracking-[0.28em] text-white/70">
                     Studio VBG
                   </SheetTitle>
-                  <p className="text-xs text-white/50">Navigation principale</p>
+                  <p className="text-sm text-white/50">Navigation principale</p>
                 </SheetHeader>
 
                 <div className="flex h-full flex-col gap-8 px-6 py-8">
@@ -266,33 +264,36 @@ export function HeaderRoot() {
                     {MAIN_NAV.map((item) => {
                       const hasNested = Boolean(
                         ("children" in item && item.children?.length) ||
-                          ("mega" in item && item.mega?.length)
+                          ("mega" in item && item.mega?.length),
                       );
+
                       if (!hasNested) {
                         return (
                           <SheetClose asChild key={item.href}>
                             <Link
                               to={item.href}
-                              className="block rounded-2xl border border-white/10 bg-white/5 px-4 py-3 uppercase tracking-[0.3em] text-white transition hover:bg-white/10"
+                              className="block rounded-xl border border-white/15 bg-white/5 px-4 py-3 uppercase tracking-[0.28em] text-white transition hover:bg-white/10"
                             >
                               {item.label}
                             </Link>
                           </SheetClose>
                         );
                       }
+
                       const nestedLinks =
                         ("children" in item && item.children) ||
                         ("mega" in item && item.mega) ||
                         [];
+
                       return (
                         <Accordion
                           key={item.label}
                           type="single"
                           collapsible
-                          className="rounded-2xl border border-white/10 bg-white/5"
+                          className="rounded-xl border border-white/15 bg-white/[0.04]"
                         >
                           <AccordionItem value={item.href ?? item.label}>
-                            <AccordionTrigger className="px-4 py-3 text-left text-sm uppercase tracking-[0.3em] text-white">
+                            <AccordionTrigger className="px-4 py-3 text-left text-xs uppercase tracking-[0.28em] text-white">
                               {item.label}
                             </AccordionTrigger>
                             <AccordionContent className="space-y-2 px-4 pb-4">
@@ -300,7 +301,7 @@ export function HeaderRoot() {
                                 <SheetClose asChild>
                                   <Link
                                     to={item.href}
-                                    className="block rounded-xl border border-white/10 bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white/80 transition hover:bg-white/15 hover:text-white"
+                                    className="block rounded-lg border border-white/10 bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-white/80 transition hover:bg-white/15 hover:text-white"
                                   >
                                     Voir tout
                                   </Link>
@@ -310,15 +311,14 @@ export function HeaderRoot() {
                                 <SheetClose asChild key={link.href}>
                                   <Link
                                     to={link.href}
-                                    className="block rounded-xl border border-white/5 bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white/80 transition hover:bg-white/15 hover:text-white"
+                                    className="block rounded-lg border border-white/5 bg-white/[0.08] px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-white/75 transition hover:bg-white/12 hover:text-white"
                                   >
                                     <div>{link.label}</div>
-                                    {"excerpt" in link &&
-                                      link.excerpt && (
-                                        <p className="pt-1 text-[0.65rem] normal-case text-white/60">
-                                          {String(link.excerpt)}
-                                        </p>
-                                      )}
+                                    {"excerpt" in link && link.excerpt ? (
+                                      <p className="pt-1 text-[0.7rem] normal-case text-white/60">
+                                        {String(link.excerpt)}
+                                      </p>
+                                    ) : null}
                                   </Link>
                                 </SheetClose>
                               ))}
@@ -330,11 +330,11 @@ export function HeaderRoot() {
                   </nav>
 
                   <div className="mt-auto space-y-4">
-                    <div className="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                    <div className="flex items-center justify-between rounded-xl border border-white/10 bg-white/[0.04] px-4 py-3 text-xs uppercase tracking-[0.28em] text-white/70">
                       <button
                         type="button"
                         onClick={() => setCommandOpen(true)}
-                        className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-white/80 transition hover:text-white"
+                        className="inline-flex items-center gap-2 text-white/80 transition hover:text-white"
                       >
                         <Search className="h-4 w-4" />
                         Rechercher (⌘K)
@@ -342,7 +342,7 @@ export function HeaderRoot() {
                       <button
                         type="button"
                         onClick={toggleTheme}
-                        className="rounded-full border border-white/10 p-2 text-white/70 transition hover:bg-white/10 hover:text-white"
+                        className="rounded-full border border-white/10 p-2 text-white/80 transition hover:bg-white/10 hover:text-white"
                         aria-label="Changer de thème"
                       >
                         {theme === "dark" ? (
@@ -353,7 +353,7 @@ export function HeaderRoot() {
                       </button>
                     </div>
 
-                    <div className="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-xs uppercase tracking-[0.3em] text-white/70">
+                    <div className="flex items-center justify-between rounded-xl border border-white/10 bg-white/[0.04] px-4 py-3 text-xs uppercase tracking-[0.28em] text-white/70">
                       <span>Langue</span>
                       <button
                         type="button"
@@ -367,17 +367,9 @@ export function HeaderRoot() {
                     <SheetClose asChild>
                       <Link
                         to={ctaHref}
-                        className="block rounded-full border border-white/20 bg-white px-6 py-3 text-center text-xs font-semibold uppercase tracking-[0.35em] text-slate-950 transition hover:bg-white/90"
+                        className="block rounded-full border border-white/20 bg-white px-6 py-3 text-center text-xs font-semibold uppercase tracking-[0.3em] text-slate-950 transition hover:bg-white/90"
                       >
                         {ctaLabel}
-                      </Link>
-                    </SheetClose>
-                    <SheetClose asChild>
-                      <Link
-                        to="/connexion"
-                        className="block rounded-full border border-white/10 bg-white/5 px-5 py-3 text-center text-xs font-semibold uppercase tracking-[0.3em] text-white/80 transition hover:bg-white/10 hover:text-white"
-                      >
-                        Connexion
                       </Link>
                     </SheetClose>
                   </div>
@@ -385,380 +377,278 @@ export function HeaderRoot() {
               </SheetContent>
             </Sheet>
 
-            {/* Brand */}
             <Link
               to="/"
-              className="group inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-[0.4em] text-white transition hover:border-white/30 hover:bg-white/10"
+              className="inline-flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white transition hover:border-white/30 hover:bg-white/10"
             >
-              <span className="relative hidden sm:inline">
-                <AnimatePresence>
-                  {navReady && (
-                    <motion.span
-                      className="absolute -inset-y-1 -inset-x-2 rounded-full bg-white/40 opacity-0 blur-md"
-                      initial={{ opacity: 0, scale: 0.9 }}
-                      animate={{ opacity: 0.45, scale: 1 }}
-                      exit={{ opacity: 0 }}
-                      transition={{ duration: 0.6, ease: [0.25, 1, 0.5, 1] }}
-                    />
-                  )}
-                </AnimatePresence>
-                <span className="relative">Studio VBG</span>
-              </span>
+              Studio VBG
             </Link>
           </div>
 
-          {/* Desktop nav */}
-          <NavigationMenu className="hidden flex-1 justify-center lg:flex">
-            <NavigationMenuList className="flex items-center gap-6">
-              {MAIN_NAV.map((item) => {
-                const hasNested = Boolean(
-                  ("children" in item && item.children?.length) ||
-                    ("mega" in item && item.mega?.length)
-                );
-                if (!hasNested) {
-                  return (
-                    <NavigationMenuItem key={item.href}>
-                      <NavigationMenuLink asChild>
-                        <NavLink
-                          to={item.href}
-                          className={({ isActive }) =>
-                            cn(
-                              "group relative inline-flex flex-col items-center gap-2 text-sm font-medium uppercase tracking-[0.3em] text-white/70 transition-colors duration-300",
-                              isActive && "text-white"
-                            )
-                          }
-                        >
-                          {({ isActive }) => (
-                            <motion.span
-                              className="relative inline-flex flex-col items-center gap-2"
-                              initial="inactive"
-                              animate={isActive ? "active" : "inactive"}
-                              whileHover="hover"
-                              variants={{
-                                inactive: { opacity: 1 },
-                                hover: { opacity: 1 },
-                                active: { opacity: 1 },
-                              }}
-                            >
-                              <span className="relative px-2 py-1">
-                                <AnimatePresence>
-                                  {isActive && (
-                                    <motion.span
-                                      layoutId="nav-label-glow"
-                                      className="absolute inset-0 rounded-full bg-white/10 blur-md"
-                                      initial={{ opacity: 0, scale: 0.85 }}
-                                      animate={{ opacity: 0.45, scale: 1 }}
-                                      exit={{ opacity: 0, scale: 0.9 }}
-                                      transition={navUnderlineTransition}
-                                    />
-                                  )}
-                                </AnimatePresence>
-                                <span className="relative z-10">
-                                  {item.label}
-                                </span>
-                              </span>
-                              <motion.span
-                                aria-hidden
-                                className="h-[2px] w-full rounded-full bg-gradient-to-r from-cyan-400/80 via-fuchsia-400/80 to-purple-500/80"
-                                variants={{
-                                  inactive: { scaleX: 0, opacity: 0 },
-                                  hover: { scaleX: 1, opacity: 0.4 },
-                                  active: { scaleX: 1, opacity: 1 },
-                                }}
-                                transition={navUnderlineTransition}
-                                style={{ transformOrigin: "center" }}
-                              />
-                            </motion.span>
-                          )}
-                        </NavLink>
-                      </NavigationMenuLink>
-                    </NavigationMenuItem>
-                  );
-                }
+          <DesktopNavigation
+            dropdownMotion={dropdownMotion}
+            indicatorTransition={indicatorTransition}
+          />
 
-                if ("children" in item && item.children?.length) {
-                  return (
-                    <NavigationMenuItem key={item.label}>
-                      <NavigationMenuTrigger className="group border border-white/10 bg-transparent text-sm font-medium uppercase tracking-[0.3em] text-white/70 transition-colors hover:border-white/20 hover:bg-white/10 hover:text-white data-[state=open]:border-white/40 data-[state=open]:bg-white/10 data-[state=open]:text-white">
-                        <span className="relative inline-flex items-center gap-2 px-2 py-1">
-                          <AnimatePresence>
-                            {navReady && (
-                              <motion.span
-                                className="absolute inset-0 rounded-full bg-white/5"
-                                initial={{ opacity: 0, scale: 0.85 }}
-                                animate={{ opacity: 1, scale: 1 }}
-                                exit={{ opacity: 0 }}
-                                transition={{
-                                  duration: 0.45,
-                                  ease: [0.25, 1, 0.5, 1],
-                                }}
-                              />
-                            )}
-                          </AnimatePresence>
-                          <span className="relative z-10">{item.label}</span>
-                        </span>
-                      </NavigationMenuTrigger>
-                      <NavigationMenuContent className="mt-3 overflow-visible">
-                        <motion.div
-                          className="relative w-80 overflow-hidden rounded-[1.85rem] border border-white/15 bg-slate-950/90 p-4 text-white shadow-[0_28px_70px_rgba(15,23,42,0.55)] backdrop-blur-2xl"
-                          initial={{ opacity: 0, y: 14, scale: 0.95 }}
-                          animate={{ opacity: 1, y: 0, scale: 1 }}
-                          exit={{ opacity: 0, y: 12, scale: 0.97 }}
-                          transition={{
-                            duration: 0.38,
-                            ease: [0.16, 1, 0.3, 1],
-                          }}
-                        >
-                          <motion.span
-                            aria-hidden
-                            className="pointer-events-none absolute -inset-px rounded-[2rem] bg-gradient-to-br from-cyan-400/25 via-fuchsia-400/10 to-indigo-500/15 opacity-50 blur-2xl"
-                            initial={{ opacity: 0, scale: 0.9 }}
-                            animate={{ opacity: 1, scale: 1 }}
-                            transition={{
-                              duration: 0.6,
-                              ease: [0.22, 1, 0.36, 1],
-                            }}
-                          />
-                          <div className="relative z-10 space-y-3">
-                            <NavigationMenuLink asChild>
-                              <Link
-                                to={item.href ?? "#"}
-                                className="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-white/80 transition hover:border-white/30 hover:bg-white/10 hover:text-white"
-                              >
-                                Voir tout
-                                <ArrowUpRight className="h-3.5 w-3.5" />
-                              </Link>
-                            </NavigationMenuLink>
-                            <motion.ul className="grid gap-2">
-                              {item.children.map((child, index) => (
-                                <motion.li
-                                  key={child.href}
-                                  initial={{ opacity: 0, y: 10 }}
-                                  animate={{ opacity: 1, y: 0 }}
-                                  transition={{
-                                    duration: 0.35,
-                                    ease: [0.16, 1, 0.3, 1],
-                                    delay: index * 0.05,
-                                  }}
-                                >
-                                  <Link
-                                    to={child.href}
-                                    className="block rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white/80 transition hover:border-white/30 hover:bg-white/10 hover:text-white"
-                                  >
-                                    {child.label}
-                                  </Link>
-                                </motion.li>
-                              ))}
-                            </motion.ul>
-                          </div>
-                        </motion.div>
-                      </NavigationMenuContent>
-                    </NavigationMenuItem>
-                  );
-                }
-
-                return (
-                  <NavigationMenuItem key={item.label}>
-                    <NavigationMenuTrigger className="group border border-white/10 bg-transparent text-sm font-medium uppercase tracking-[0.3em] text-white/70 transition-colors hover:border-white/20 hover:bg-white/10 hover:text-white data-[state=open]:border-white/40 data-[state=open]:bg-white/10 data-[state=open]:text-white">
-                      <span className="relative inline-flex items-center gap-2 px-2 py-1">
-                        <AnimatePresence>
-                          {navReady && (
-                            <motion.span
-                              className="absolute inset-0 rounded-full bg-white/5"
-                              initial={{ opacity: 0, scale: 0.85 }}
-                              animate={{ opacity: 1, scale: 1 }}
-                              exit={{ opacity: 0 }}
-                              transition={{
-                                duration: 0.45,
-                                ease: [0.25, 1, 0.5, 1],
-                              }}
-                            />
-                          )}
-                        </AnimatePresence>
-                        <span className="relative z-10">{item.label}</span>
-                      </span>
-                    </NavigationMenuTrigger>
-                    <NavigationMenuContent className="mt-4 overflow-visible">
-                      <motion.div
-                        className="relative w-[720px] overflow-hidden rounded-[2.25rem] border border-white/15 bg-slate-950/95 p-6 text-white shadow-[0_32px_80px_rgba(15,23,42,0.6)] backdrop-blur-2xl"
-                        initial={{ opacity: 0, y: 18, scale: 0.94 }}
-                        animate={{ opacity: 1, y: 0, scale: 1 }}
-                        exit={{ opacity: 0, y: 16, scale: 0.97 }}
-                        transition={{ duration: 0.42, ease: [0.16, 1, 0.3, 1] }}
-                      >
-                        <motion.span
-                          aria-hidden
-                          className="pointer-events-none absolute -inset-px rounded-[2.35rem] bg-[conic-gradient(at_top_left,_theme(colors.cyan.400/18),_transparent_35%,_theme(colors.fuchsia.400/14),_transparent_70%,_theme(colors.sky.400/18))] opacity-60 blur-3xl"
-                          initial={{ opacity: 0, rotate: -8 }}
-                          animate={{ opacity: 1, rotate: 0 }}
-                          transition={{ duration: 0.75, ease: [0.22, 1, 0.36, 1] }}
-                        />
-                        <div className="relative z-10 space-y-4">
-                          <NavigationMenuLink asChild>
-                            <Link
-                              to={item.href ?? "#"}
-                              className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-white/80 transition hover:border-white/30 hover:bg-white/10 hover:text-white"
-                            >
-                              Voir tout
-                              <ArrowUpRight className="h-3.5 w-3.5" />
-                            </Link>
-                          </NavigationMenuLink>
-                          <motion.div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-                            {"mega" in item && item.mega
-                              ? item.mega.map((entry, index) => (
-                                  <motion.div
-                                    key={entry.href}
-                                    initial={{ opacity: 0, y: 12 }}
-                                    animate={{ opacity: 1, y: 0 }}
-                                    transition={{
-                                      duration: 0.4,
-                                      ease: [0.16, 1, 0.3, 1],
-                                      delay: index * 0.05,
-                                    }}
-                                  >
-                                    <Link
-                                      to={entry.href}
-                                      className="group flex h-full flex-col gap-3 rounded-2xl border border-white/10 bg-white/5 p-4 transition hover:border-white/40 hover:bg-white/10"
-                                    >
-                                      <span className="text-xs font-semibold uppercase tracking-[0.3em] text-cyan-200/80">
-                                        {entry.label}
-                                      </span>
-                                      <p className="text-sm text-white/70">
-                                        {entry.excerpt}
-                                      </p>
-                                      <span className="inline-flex items-center gap-2 text-[0.65rem] uppercase tracking-[0.3em] text-white/60 transition group-hover:translate-x-1">
-                                        Explorer
-                                        <ArrowUpRight className="h-3.5 w-3.5" />
-                                      </span>
-                                    </Link>
-                                  </motion.div>
-                                ))
-                              : null}
-                          </motion.div>
-                        </div>
-                      </motion.div>
-                    </NavigationMenuContent>
-                  </NavigationMenuItem>
-                );
-              })}
-            </NavigationMenuList>
-          </NavigationMenu>
-
-          {/* Right: actions */}
-          <div className="ml-auto hidden items-center gap-2 lg:flex">
+          <div className="hidden items-center gap-2 lg:flex">
+            <button
+              type="button"
+              onClick={() => setCommandOpen(true)}
+              className="inline-flex h-10 items-center gap-2 rounded-full border border-white/10 px-4 text-xs font-semibold uppercase tracking-[0.28em] text-white/70 transition hover:text-white"
+            >
+              <Search className="h-4 w-4" />
+              Rechercher
+            </button>
+            <button
+              type="button"
+              onClick={toggleLanguage}
+              className="inline-flex h-10 items-center rounded-full border border-white/10 px-3 text-xs font-semibold uppercase tracking-[0.28em] text-white/70 transition hover:bg-white/10 hover:text-white"
+            >
+              {language}
+            </button>
+            <button
+              type="button"
+              onClick={toggleTheme}
+              className="inline-flex h-10 items-center justify-center rounded-full border border-white/10 px-3 text-white/70 transition hover:bg-white/10 hover:text-white"
+              aria-label="Changer de thème"
+            >
+              {theme === "dark" ? (
+                <SunMedium className="h-4 w-4" />
+              ) : (
+                <MoonStar className="h-4 w-4" />
+              )}
+            </button>
             <Button
               asChild
-              className="rounded-full border border-white/10 bg-white/5 px-5 text-xs font-semibold uppercase tracking-[0.35em] text-white/80 hover:bg-white/10 hover:text-white"
+              className="rounded-full border border-transparent bg-white px-5 text-xs font-semibold uppercase tracking-[0.3em] text-slate-950 hover:bg-white/90"
             >
-              <Link to="/connexion">Connexion</Link>
+              <Link to={ctaHref}>{ctaLabel}</Link>
             </Button>
           </div>
         </div>
 
-        {/* Secondary subnav */}
         {subNavItems.length > 0 && (
-          <div className="relative z-10 border-t border-white/10 bg-slate-950/80">
+          <div className="border-t border-white/10 bg-slate-950/75">
             <div className="mx-auto max-w-6xl px-4">
               <nav className="flex gap-3 overflow-x-auto py-3">
-                {subNavItems.map((item) => {
-                  const isActive = item.href.endsWith(`/${activeSubnavSlug}`);
-                  return (
-                    <NavLink
-                      key={item.href}
-                      to={item.href}
-                      className="group relative inline-flex focus:outline-none"
-                    >
-                      {({ isActive: routeActive }) => {
-                        const active = isActive || routeActive;
-                        return (
-                          <span
-                            className={cn(
-                              "relative inline-flex items-center justify-center overflow-hidden rounded-full border px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] transition-colors duration-300 group-focus-visible:ring-2 group-focus-visible:ring-white/40 group-focus-visible:ring-offset-2 group-focus-visible:ring-offset-slate-950",
-                              active
-                                ? "border-white/40 text-white"
-                                : "border-white/10 text-white/60 hover:border-white/20 hover:text-white"
-                            )}
-                          >
-                            <AnimatePresence>
-                              {active && (
-                                <motion.span
-                                  layoutId="subnav-highlight"
-                                  className="absolute inset-0 rounded-full bg-white/10"
-                                  initial={{ opacity: 0, scale: 0.9 }}
-                                  animate={{ opacity: 1, scale: 1 }}
-                                  exit={{ opacity: 0, scale: 0.95 }}
-                                  transition={subnavHighlightTransition}
-                                />
-                              )}
-                            </AnimatePresence>
-                            <span className="relative z-10">{item.label}</span>
-                          </span>
-                        );
-                      }}
-                    </NavLink>
-                  );
-                })}
+                {subNavItems.map((item) => (
+                  <NavLink
+                    key={item.href}
+                    to={item.href}
+                    className="group relative inline-flex focus:outline-none"
+                  >
+                    {({ isActive }) => {
+                      const active =
+                        isActive || item.href.endsWith(`/${activeSubnavSlug}`);
+
+                      return (
+                        <span
+                          className={cn(
+                            "relative inline-flex items-center justify-center rounded-full border px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] transition",
+                            active
+                              ? "border-white/40 text-white"
+                              : "border-white/15 text-white/60 hover:border-white/25 hover:text-white",
+                          )}
+                        >
+                          <AnimatePresence>
+                            {active ? (
+                              <motion.span
+                                layoutId="subnav-indicator"
+                                className="absolute inset-0 rounded-full bg-white/10"
+                                initial={{ opacity: 0, scale: 0.9 }}
+                                animate={{ opacity: 1, scale: 1 }}
+                                exit={{ opacity: 0, scale: 0.95 }}
+                                transition={indicatorTransition}
+                              />
+                            ) : null}
+                          </AnimatePresence>
+                          <span className="relative z-10">{item.label}</span>
+                        </span>
+                      );
+                    }}
+                  </NavLink>
+                ))}
               </nav>
             </div>
           </div>
         )}
       </header>
 
-      {/* Command palette */}
       <CommandDialog open={commandOpen} onOpenChange={setCommandOpen}>
         <CommandInput placeholder="Rechercher une page, un service ou une réalisation..." />
         <CommandList>
-          <CommandEmpty>Aucun résultat pour cette recherche.</CommandEmpty>
-
+          <CommandEmpty>Aucun résultat</CommandEmpty>
           <CommandGroup heading="Navigation">
             {commandGroups.primary.map((item) => (
               <CommandItem
                 key={item.href}
-                value={item.label}
-                onSelect={() => {
-                  navigate(item.href);
-                  setCommandOpen(false);
-                }}
+                value={item.href}
+                onSelect={handleCommandSelect}
               >
                 {item.label}
                 <CommandShortcut>↵</CommandShortcut>
               </CommandItem>
             ))}
           </CommandGroup>
-
           <CommandSeparator />
-
           <CommandGroup heading="Services">
             {commandGroups.services.map((item) => (
               <CommandItem
                 key={item.href}
-                value={item.label}
-                onSelect={() => {
-                  navigate(item.href);
-                  setCommandOpen(false);
-                }}
+                value={item.href}
+                onSelect={handleCommandSelect}
               >
                 {item.label}
+                <CommandShortcut>↵</CommandShortcut>
               </CommandItem>
             ))}
           </CommandGroup>
-
           <CommandGroup heading="Réalisations">
             {commandGroups.works.map((item) => (
               <CommandItem
                 key={item.href}
-                value={item.label}
-                onSelect={() => {
-                  navigate(item.href);
-                  setCommandOpen(false);
-                }}
+                value={item.href}
+                onSelect={handleCommandSelect}
               >
                 {item.label}
+                <CommandShortcut>↵</CommandShortcut>
               </CommandItem>
             ))}
           </CommandGroup>
         </CommandList>
       </CommandDialog>
     </Fragment>
+  );
+}
+
+type DesktopNavigationProps = {
+  dropdownMotion: {
+    initial: Record<string, unknown>;
+    animate: Record<string, unknown>;
+    exit: Record<string, unknown>;
+  };
+  indicatorTransition: typeof indicatorTransition;
+};
+
+function DesktopNavigation({
+  dropdownMotion,
+  indicatorTransition,
+}: DesktopNavigationProps) {
+  const location = useLocation();
+
+  return (
+    <NavigationMenu className="hidden flex-1 justify-center lg:flex">
+      <NavigationMenuList className="flex items-center gap-6">
+        {MAIN_NAV.map((item) => {
+          const hasNested = Boolean(
+            ("children" in item && item.children?.length) ||
+              ("mega" in item && item.mega?.length),
+          );
+
+          if (!hasNested) {
+            return (
+              <NavigationMenuItem key={item.href}>
+                <NavigationMenuLink asChild>
+                  <NavLink
+                    to={item.href}
+                    className="relative inline-flex flex-col items-center gap-1 text-sm font-semibold uppercase tracking-[0.26em] text-white/70 transition hover:text-white"
+                  >
+                    {({ isActive }) => (
+                      <span className="relative">
+                        {item.label}
+                        <AnimatePresence>
+                          {isActive ? (
+                            <motion.span
+                              layoutId="nav-indicator"
+                              className="absolute -bottom-1 left-1/2 h-0.5 w-full -translate-x-1/2 rounded-full bg-white"
+                              initial={{ opacity: 0, scaleX: 0.6 }}
+                              animate={{ opacity: 1, scaleX: 1 }}
+                              exit={{ opacity: 0, scaleX: 0.6 }}
+                              transition={indicatorTransition}
+                              style={{ transformOrigin: "center" }}
+                            />
+                          ) : null}
+                        </AnimatePresence>
+                      </span>
+                    )}
+                  </NavLink>
+                </NavigationMenuLink>
+              </NavigationMenuItem>
+            );
+          }
+
+          const nestedLinks =
+            ("children" in item && item.children) ||
+            ("mega" in item && item.mega) ||
+            [];
+
+          return (
+            <NavigationMenuItem key={item.label}>
+              <NavigationMenuTrigger className="inline-flex flex-col items-center gap-1 rounded-full border border-transparent bg-transparent px-3 py-2 text-sm font-semibold uppercase tracking-[0.26em] text-white/70 transition hover:text-white data-[state=open]:bg-white/10 data-[state=open]:text-white">
+                <span>{item.label}</span>
+                <AnimatePresence>
+                  {typeof item.href === "string" &&
+                  location.pathname.startsWith(item.href) ? (
+                    <motion.span
+                      layoutId="nav-indicator"
+                      className="h-0.5 w-full rounded-full bg-white"
+                      initial={{ opacity: 0, scaleX: 0.6 }}
+                      animate={{ opacity: 1, scaleX: 1 }}
+                      exit={{ opacity: 0, scaleX: 0.6 }}
+                      transition={indicatorTransition}
+                      style={{ transformOrigin: "center" }}
+                    />
+                  ) : null}
+                </AnimatePresence>
+              </NavigationMenuTrigger>
+              <NavigationMenuContent asChild>
+                <motion.div
+                  {...dropdownMotion}
+                  className="mt-3 w-[min(28rem,90vw)] rounded-2xl border border-white/10 bg-slate-950/95 p-5 shadow-lg backdrop-blur"
+                >
+                  <div className="flex flex-col gap-4">
+                    {item.href ? (
+                      <NavigationMenuLink asChild>
+                        <Link
+                          to={item.href}
+                          className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.26em] text-white/80 transition hover:text-white"
+                        >
+                          Tout voir
+                          <ArrowUpRight className="h-3.5 w-3.5" />
+                        </Link>
+                      </NavigationMenuLink>
+                    ) : null}
+
+                    <div className="grid gap-3 sm:grid-cols-2">
+                      {nestedLinks.map((link) => (
+                        <NavigationMenuLink asChild key={link.href}>
+                          <Link
+                            to={link.href}
+                            className="group flex h-full flex-col gap-2 rounded-xl border border-white/10 bg-white/[0.04] p-4 text-left transition hover:border-white/25 hover:bg-white/10"
+                          >
+                            <span className="text-xs font-semibold uppercase tracking-[0.26em] text-cyan-200/70">
+                              {link.label}
+                            </span>
+                            {"excerpt" in link && link.excerpt ? (
+                              <p className="text-sm text-white/70">
+                                {link.excerpt}
+                              </p>
+                            ) : null}
+                            <span className="inline-flex items-center gap-2 text-[0.7rem] uppercase tracking-[0.26em] text-white/60 transition group-hover:text-white">
+                              Explorer
+                              <ArrowUpRight className="h-3 w-3" />
+                            </span>
+                          </Link>
+                        </NavigationMenuLink>
+                      ))}
+                    </div>
+                  </div>
+                </motion.div>
+              </NavigationMenuContent>
+            </NavigationMenuItem>
+          );
+        })}
+      </NavigationMenuList>
+    </NavigationMenu>
   );
 }

--- a/src/components/header/nav.config.ts
+++ b/src/components/header/nav.config.ts
@@ -1,32 +1,31 @@
 const excerptMap = {
-  entreprise: "Film manifeste + preuves sociales prêtes pour vos RDV commerciaux",
-  evenementiel: "Aftermovie J+3 et capsules verticales pour sponsors & réseaux",
-  immobilier: "Visite 4K HDR + version verticale optimisée annonces premium",
-  "reseaux-sociaux": "Séries mensuelles 9:16 montées avec scripts et sous-titres",
-  mariage: "Film cinématique + bande-annonce émotions fortes 72 h",
-  "motion-design-ia": "Motion narratif mêlant design & IA générative pour expliquer",
+  entreprise: "Films de marque, interviews et témoignages cadrés conversion",
+  evenementiel: "Aftermovies dynamiques, teasers J-3 et captations conférences",
+  immobilier: "Visites 4K lumineuses, plans drone & bandeaux infos",
+  mariage: "Récits ciné lumineux + teaser vertical livré sous 72 h",
+  "reseaux-sociaux": "Capsules verticales, formats ads et séries éditoriales",
+  "motion-ia": "Expériences hybrides : motion design, IA générative, volumétrique",
 } as const;
 
 export const CATEGORIES = [
   { label: "Entreprise", slug: "entreprise" },
   { label: "Événementiel", slug: "evenementiel" },
   { label: "Immobilier", slug: "immobilier" },
-  { label: "Réseaux sociaux", slug: "reseaux-sociaux" },
   { label: "Mariage", slug: "mariage" },
-  { label: "Motion design / IA", slug: "motion-design-ia" },
+  { label: "Réseaux sociaux", slug: "reseaux-sociaux" },
+  { label: "Motion Design / IA", slug: "motion-ia" },
 ] as const;
 
 export type Category = (typeof CATEGORIES)[number];
 export type CategorySlug = Category["slug"];
 
 export const MAIN_NAV = [
-  { label: "Accueil", href: "/" },
   {
     label: "Réalisations",
-    href: "/realisations",
+    href: "/portfolio",
     children: CATEGORIES.map((category) => ({
       label: category.label,
-      href: `/realisations/${category.slug}`,
+      href: `/portfolio/${category.slug}`,
     })),
   },
   {

--- a/src/index.css
+++ b/src/index.css
@@ -8,6 +8,10 @@ All colors MUST be HSL.
 
 @layer base {
   :root {
+    --font-sans: "Inter", "Inter var", -apple-system, BlinkMacSystemFont,
+      "Segoe UI", sans-serif;
+    --font-display: "Newsreader", "Source Serif Pro", "Iowan Old Style",
+      serif;
     --background: 0 0% 100%;
     --foreground: 222.2 84% 4.9%;
 
@@ -92,6 +96,29 @@ All colors MUST be HSL.
     --sidebar-accent-foreground: 240 4.8% 95.9%;
     --sidebar-border: 240 3.7% 15.9%;
     --sidebar-ring: 217.2 91.2% 59.8%;
+  }
+
+  * {
+    font-feature-settings: "kern" 1;
+  }
+
+  body {
+    font-family: var(--font-sans);
+    font-size: 16px;
+    font-synthesis: none;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+    background-color: hsl(var(--background));
+    color: hsl(var(--foreground));
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: var(--font-display);
   }
 }
 

--- a/src/lib/services.ts
+++ b/src/lib/services.ts
@@ -1,350 +1,481 @@
 export type ServiceDetail = {
   slug: string;
+  name: string;
   title: string;
   subtitle: string;
-  hook: string;
-  problem: string;
-  promise: string;
-  stack: string[];
-  deliverables: string[];
+  description: string;
   timeline: string;
   startingPrice: string;
-  proof: string;
+  benefits: string[];
+  formats: { title: string; description: string }[];
+  workflow: {
+    preprod: string[];
+    production: string[];
+    postprod: string[];
+    delivery: string[];
+  };
+  process: { title: string; description: string }[];
+  deliverables: string[];
+  options?: string[];
+  pricing: { name: string; price: string; description: string }[];
   ctaLabel: string;
-  phases: {
-    title: string;
-    description: string;
-    aiUpgrade: string;
-  }[];
-  signatureMove: string;
-  metrics: { label: string; value: string; note: string }[];
+  ctaSubcopy: string;
+  faqs?: { question: string; answer: string }[];
 };
 
 export const servicesData: ServiceDetail[] = [
-  /* -------------------------------------------------- */
-  /* 1) ENTREPRISE                                      */
-  /* -------------------------------------------------- */
   {
     slug: "entreprise",
-    title: "Vidéo d’entreprise — claire, crédible, utile",
-    subtitle: "Expliquez mieux, recrutez plus, vendez sans forcer.",
-    hook: "Expliquez, recrutez, vendez — avec des films clairs et crédibles.",
-    problem:
-      "Vous avez besoin d’un film qui clarifie votre proposition de valeur autant pour les prospects que pour les talents que vous ciblez.",
-    promise:
-      "Je construis un récit structuré autour de vos objectifs business, avec interviews guidées, preuves sociales et assets prêts à diffuser sur vos canaux clés.",
-    stack: ["Sony Burano 8K", "DaVinci Resolve Neural 19", "Notion Storyboard AI", "Runway Gen-3 Alpha"],
+    name: "Vidéo d’entreprise",
+    title: "Vidéo d’entreprise — film de marque, interviews et témoignages",
+    subtitle:
+      "Humanisez votre communication et clarifiez votre offre avec des vidéos brèves, percutantes et crédibles. Idéal pour pages d’accueil, campagnes Social Ads, recrutement et onboarding.",
+    description: "Film de marque, interviews, recrutement, témoignages clients.",
+    timeline: "Livraison 5 à 10 jours ouvrés après tournage",
+    startingPrice: "À partir de 950 € HT",
+    benefits: [
+      "Crédibilité immédiate grâce aux interviews & cas clients",
+      "Efficacité : scripts courts, message mémorisable, CTA clair",
+      "Polyvalence : versions horizontales/verticales pour site, LinkedIn, Instagram",
+    ],
+    formats: [
+      { title: "Film de marque (60–90 s)", description: "Manifeste vidéo + images métier" },
+      { title: "Interview(s) / Portrait(s)", description: "Dirigeant·e, collaborateurs, clients" },
+      { title: "Témoignage client", description: "Histoire, problème, solution, résultat" },
+      { title: "Capsules social (15–30 s)", description: "Messages ciblés pour campagnes" },
+    ],
+    workflow: {
+      preprod: [
+        "Brief & objectifs alignés (positionnement, audience, KPI)",
+        "Script + questions d’interview validés avec vos équipes",
+      ],
+      production: [
+        "Tournage 1/2 à 1 journée : interviews, plans d’illustration, ambiance",
+        "Son & lumière cinéma, prompteur ou téléprompteur si besoin",
+      ],
+      postprod: [
+        "Montage narratif sous 5–7 jours, habillage et mixage inclus",
+        "Sous-titres brandés et motion design léger pour clarifier l’offre",
+      ],
+      delivery: [
+        "Master 4K + déclinaisons 1080p pour site et présentations",
+        "Capsules verticales optionnelles pour LinkedIn, Instagram, TikTok",
+      ],
+    },
+    process: [
+      { title: "Brief & objectifs", description: "Positionnement, audience, KPI" },
+      { title: "Script & feuille de route", description: "Plan d’images, questions d’interview" },
+      { title: "Tournage (1/2 à 1 journée)", description: "Son et lumière pro, prompteur si nécessaire" },
+      { title: "Montage", description: "1ère version sous 5–7 jours" },
+      { title: "Allers-retours", description: "2 séries d’ajustements incluses" },
+    ],
     deliverables: [
-      "Film principal 60–90 s (16:9)",
-      "3 déclinaisons courtes 15–30 s (9:16 & 1:1)",
-      "Pack sous-titres FR/EN + miniatures brandées",
+      "1 master en 4K + déclinaisons 1080p",
+      "Sous-titres (.srt) + version incrustée",
+      "Couverture miniature optimisée (YouTube/LinkedIn)",
     ],
-    timeline: "10–15 jours ouvrés",
-    startingPrice: "À partir de 1 900 € HT",
-    proof: "+38 % d’inscriptions à un webinaire (cas client)",
-    ctaLabel: "Découvrir le service Entreprise",
-    phases: [
+    options: ["Drone (selon zone)", "Motion design léger", "Voix-off", "Sound design", "Photos making-of"],
+    pricing: [
       {
-        title: "Brief & objectifs",
-        description: "Session de cadrage 30 min pour prioriser vos messages, audiences et KPI.",
-        aiUpgrade: "Synthèse automatique des enjeux et moodboard instantané partagé à l’équipe.",
+        name: "Pack Journée",
+        price: "1 200–1 600 € HT",
+        description: "1 journée, 2 interviews, film 60–75 s + déclinaison verticale",
       },
       {
-        title: "Scénario & planning",
-        description: "Scripts interview, repérages, organisation plateau et validation direction.",
-        aiUpgrade: "Storyboard génératif + checklist logistique intelligente.",
+        name: "Pack Weekend",
+        price: "2 200–2 800 € HT",
+        description: "2 journées (tournage + B-roll), film 90 s + 3 capsules sociales",
       },
       {
-        title: "Tournage cinématique",
-        description: "Interviews multicam, B-roll immersif, captation audio double système.",
-        aiUpgrade: "Téléprompteur adaptatif et monitoring colorimétrique en direct.",
-      },
-      {
-        title: "Montage & révisions",
-        description: "Montage narratif, motion léger, habillage sonore, 2 allers-retours inclus.",
-        aiUpgrade: "Suggestions de cuts par IA vérifiées humainement pour accélérer les itérations.",
-      },
-      {
-        title: "Activation multicanale",
-        description: "Exports LinkedIn, YouTube, intranet + scripts de diffusion prêts à publier.",
-        aiUpgrade: "Assistant publication pour générer posts et thumbnails optimisés.",
+        name: "Pack Sur Demande",
+        price: "Sur devis rapide",
+        description: "Déploiement multi-sites, motion avancé, voix-off premium",
       },
     ],
-    signatureMove: "Teaser 45 s livré sous 72 h pour vos comités ou campagnes teasing.",
-    metrics: [
-      { label: "Preuve", value: "+38%", note: "d’inscriptions webinar (cas client 2025)" },
-      { label: "Délais", value: "10–15 j", note: "ouvrés selon agenda tournage" },
-      { label: "Itérations", value: "≤2", note: "grâce au script validé en amont" },
-    ],
+    ctaLabel: "Parler de votre projet",
+    ctaSubcopy: "Devis en 24 h, simple et sans jargon.",
   },
-
-  /* -------------------------------------------------- */
-  /* 2) ÉVÉNEMENTIEL                                    */
-  /* -------------------------------------------------- */
   {
     slug: "evenementiel",
-    title: "Aftermovie & contenus événementiels — l’énergie qui reste",
-    subtitle: "Faites revivre, vendez le prochain.",
-    hook: "Faites revivre votre événement, et donnez envie de venir au prochain.",
-    problem:
-      "Vous devez capitaliser à chaud sur l’émotion des participants et fournir des preuves tangibles à vos sponsors.",
-    promise:
-      "Je capte l’événement avec une équipe mobile, monte en flux tendu et livre un aftermovie vibrant accompagné de capsules verticales prêtes à poster.",
-    stack: ["Sony FX6 Duo", "DJI Inspire 3", "Veo Live Suite", "Suno Studio Max"],
-    deliverables: ["Aftermovie 60–90 s", "5 capsules verticales 10–15 s", "Galerie photo optionnelle"],
-    timeline: "J+3 à J+7",
-    startingPrice: "À partir de 1 400 € HT",
-    proof: "Taux de réinscription +24 %",
-    ctaLabel: "Voir le service Événementiel",
-    phases: [
+    name: "Vidéos événementielles",
+    title: "Aftermovie & captation — mettez votre événement en valeur",
+    subtitle:
+      "Du teaser d’avant à l’aftermovie qui prolonge l’émotion, je capture l’énergie de votre événement et vos messages clés (conférences, salons, séminaires, concerts, lancements).",
+    description: "Aftermovie, teaser, captation conférences & salons.",
+    timeline: "Livraison standard J+5 (option express J+2)",
+    startingPrice: "À partir de 1 500 € HT",
+    benefits: [
+      "Réactivité terrain : équipe légère, discrète, multi-cam possible",
+      "Storytelling : rythme + sound design pour un rendu dynamique",
+      "Livraison rapide pour vos remerciements et réseaux sociaux",
+    ],
+    formats: [
+      { title: "Teaser 20–40 s", description: "Pour annoncer l’événement" },
+      { title: "Aftermovie 60–120 s", description: "Résumé émotion + messages clés" },
+      { title: "Captation Talks", description: "Multi-cam possible" },
+      { title: "Clips réseaux", description: "Verticals 10–20 s" },
+    ],
+    workflow: {
+      preprod: [
+        "Repérage et cadrage des moments clés + interviews",
+        "Storyboard express & planning logistique avec vos équipes",
+      ],
+      production: [
+        "Couverture terrain en équipe légère (1 à 2 caméras + drone le cas échéant)",
+        "Interviews participants/speakers, captation son dédiée",
+      ],
+      postprod: [
+        "Montage express possible (J+2/J+3) avec sound design immersif",
+        "Habillage graphique sponsor / branding événement",
+      ],
+      delivery: [
+        "Aftermovie 4K + versions verticales, miniatures personnalisées",
+        "Clips réseaux optimisés + exports streaming (YouTube, Vimeo, Vercel)",
+      ],
+    },
+    process: [
+      { title: "Repérage", description: "Analyse des flux et des moments forts" },
+      { title: "Planning", description: "Coordination avec vos équipes" },
+      { title: "Tournage (1 à 2 caméras)", description: "Couverture terrain + interviews" },
+      { title: "Montage express possible", description: "J+2 / J+3 selon options" },
+      { title: "Livraison", description: "Exports aftermovie + clips" },
+    ],
+    deliverables: [
+      "Master 4K/1080p",
+      "Versions verticales",
+      "Sous-titres",
+      "Miniature optimisée",
+      "Export J+5 (option express J+2)",
+    ],
+    pricing: [
       {
-        title: "Brief & objectifs",
-        description: "30 min pour valider messages sponsor, moments forts et KPIs post-event.",
-        aiUpgrade: "Feuille de route dynamique + scénarisation des séquences à capturer.",
+        name: "Pack Journée",
+        price: "1 500–2 000 € HT",
+        description: "1 caméra, 1 journée, aftermovie 60–90 s",
       },
       {
-        title: "Scénario & planning",
-        description: "Run de production, repérages et coordination avec vos équipes scène et sécurité.",
-        aiUpgrade: "Alertes logistiques IA (météo, flux visiteurs) et gestion accréditations.",
+        name: "Pack Weekend",
+        price: "2 600–3 400 € HT",
+        description: "2 jours de tournage, interviews, aftermovie 90–120 s + 3 clips",
       },
       {
-        title: "Tournage terrain",
-        description: "Multi-cam, micro-trottoirs, drone FPV indoor, captation audio immersive.",
-        aiUpgrade: "Reconnaissance VIP + tagging automatique pour retrouver les moments clés.",
-      },
-      {
-        title: "Montage & révisions",
-        description: "Montage express, étalonnage, sous-titres multilingues, brand kit sponsors.",
-        aiUpgrade: "Templates IA pour générer hooks et variations verticales en temps réel.",
-      },
-      {
-        title: "Diffusion",
-        description: "Exports prêts LinkedIn, Insta, YouTube + kit médias pour vos partenaires.",
-        aiUpgrade: "Analyse performance 72 h avec recommandations de relance.",
+        name: "Pack Sur Demande",
+        price: "Sur devis",
+        description: "Captation conférence multi-cam, diffusion live, sous-titrage express",
       },
     ],
-    signatureMove: "Aftermovie livré en J+3 maximum, stories verticales pendant l’événement.",
-    metrics: [
-      { label: "Preuve", value: "+24%", note: "de réinscriptions early-bird" },
-      { label: "Délais", value: "J+3", note: "after movie complet" },
-      { label: "Capsules", value: "5", note: "verticales prêtes à publier" },
-    ],
+    ctaLabel: "Planifier la captation",
+    ctaSubcopy: "Verrouillez la date, devis en 24 h.",
   },
-
-  /* -------------------------------------------------- */
-  /* 3) IMMOBILIER                                      */
-  /* -------------------------------------------------- */
   {
     slug: "immobilier",
-    title: "Vidéo immobilière — déclencheur de visites",
-    subtitle: "Valorisez volumes, lumière et quartier.",
-    hook: "Vendez plus vite — mettez en valeur volumes, lumière et quartier.",
-    problem:
-      "Vos annonces doivent se démarquer instantanément pour générer des demandes qualifiées avant vos concurrents.",
-    promise:
-      "Je capture le bien en 4K HDR, révèle les points forts du quartier et livre une version verticale dédiée aux portails et réseaux sociaux.",
-    stack: ["Sony A1", "DJI Avata 2", "Luma Rooms AI", "Lightroom 2025"],
-    deliverables: ["Visite vidéo 60 s", "Version verticale 30 s", "Photos HDR & plan de coupe (option)"],
-    timeline: "48–72 h après tournage",
-    startingPrice: "À partir de 650 € HT",
-    proof: "2 offres reçues en 72 h",
-    ctaLabel: "Découvrir le service Immobilier",
-    phases: [
-      {
-        title: "Brief & objectifs",
-        description: "Identification des arguments clés, calendrier et ciblage acquéreurs.",
-        aiUpgrade: "Analyse du marché local + benchmark express des annonces concurrentes.",
-      },
-      {
-        title: "Scénario & planning",
-        description: "Storyboard visite, planning tournage et check-list home staging.",
-        aiUpgrade: "Simulation de lumière horaire pour choisir le meilleur créneau.",
-      },
-      {
-        title: "Tournage sur site",
-        description: "Plans gimbal, drone intérieur/extérieur, détails architecturaux.",
-        aiUpgrade: "Stabilisation gyroscopique IA + correction de perspective en direct.",
-      },
-      {
-        title: "Montage & révisions",
-        description: "Montage rythmé, titrage quartiers, étalonnage neutre luxe.",
-        aiUpgrade: "Suggestions de call-to-action et miniatures optimisées.",
-      },
-      {
-        title: "Activation",
-        description: "Exports portails, réseaux sociaux, emailing + kit visuels.",
-        aiUpgrade: "Génération d’annonces texte prêtes à publier.",
-      },
+    name: "Vidéo immobilière",
+    title: "Visites vidéo & drone — valorisez vos biens, vendez plus vite",
+    subtitle:
+      "Des vidéos lumineuses et rythmées qui révèlent volumes, circulation et atouts du quartier. Parfait pour annonces premium, réseaux, landing pages et emailing.",
+    description: "Biens résidentiels & pros, visites filmées + drone.",
+    timeline: "Créneau sous 72 h, livraison 48–72 h après tournage",
+    startingPrice: "À partir de 450 € HT",
+    benefits: [
+      "Clarté : parcours fluide, cadrages stables, exposition maîtrisée",
+      "Gain de temps : moins de visites inutiles, meilleure qualification",
+      "Drone (selon réglementation) pour vues d’ensemble & environnements",
     ],
-    signatureMove: "Version verticale ADS incluse pour booster vos campagnes Meta/Google.",
-    metrics: [
-      { label: "Preuve", value: "2 offres", note: "reçues en 72 h (cas réel)" },
-      { label: "Délais", value: "48–72 h", note: "après tournage" },
-      { label: "Prix d’appel", value: "650 €", note: "HT" },
+    formats: [
+      { title: "Visite Essentielle", description: "Tournage 1–2 h, montage 45–60 s" },
+      { title: "Visite Premium", description: "Tournage 2–3 h, montage 60–90 s + plan de quartier" },
+      { title: "Option Drone", description: "+150–250 € HT selon zone" },
     ],
-  },
-
-  /* -------------------------------------------------- */
-  /* 4) RÉSEAUX SOCIAUX                                 */
-  /* -------------------------------------------------- */
-  {
-    slug: "reseaux-sociaux",
-    title: "Contenus courts récurrents — rester visible sans y passer vos soirées",
-    subtitle: "Un pack mensuel cadré, des posts qui sortent du lot.",
-    hook: "Un workflow mensuel pour rester visible sans y passer vos soirées.",
-    problem:
-      "Vous manquez de temps pour produire des vidéos courtes régulières sans sacrifier la cohérence de marque.",
-    promise:
-      "Je mets en place un workflow mensuel avec tournages batchés, automatisations IA et reporting clair pour nourrir vos réseaux.",
-    stack: ["Sony FX3", "Aputure Infinibar", "CapCut Pro 2025", "OpusClip AI"],
+    workflow: {
+      preprod: [
+        "Brief & check-list pour préparer le bien (lumières, détails, accessoirisation)",
+        "Repérage rapide + validation autorisations drone le cas échéant",
+      ],
+      production: [
+        "Tournage stabilisé 4K + plans slider, drone selon zone",
+        "Prises de vues complémentaires (quartier, équipements, vues extérieures)",
+      ],
+      postprod: [
+        "Montage rythmique, bandeau infos (surface, pièces, atouts)",
+        "Étalonnage lumineux + musique sous licence",
+      ],
+      delivery: [
+        "Vidéo 4K + version verticale 9:16",
+        "Miniature et pack visuels pour portail immo et réseaux",
+      ],
+    },
+    process: [
+      { title: "Brief & check-list", description: "Arguments clés et préparation du bien" },
+      { title: "Repérage & planning", description: "Créneau lumière idéal" },
+      { title: "Tournage 4K", description: "Plans stabilisés + drone si autorisé" },
+      { title: "Montage", description: "Bandeau infos, musique sous licence" },
+      { title: "Livraison multi-formats", description: "Version horizontale + verticale" },
+    ],
     deliverables: [
-      "8–16 vidéos verticales/mois",
-      "Pack sous-titres & templates titres",
-      "Calendrier éditorial + scripts hooks",
+      "1 vidéo 4K/1080p",
+      "Version verticale 9:16",
+      "Bandeau infos (surface, pièces, atouts)",
+      "Musique sous licence",
     ],
-    timeline: "Production mensuelle cadencée",
-    startingPrice: "Abonnement dès 890 € HT / mois",
-    proof: "+120 % de vues sur 60 jours",
-    ctaLabel: "Voir le service Réseaux sociaux",
-    phases: [
+    options: ["Drone", "5 photos HDR", "Plan de quartier"],
+    pricing: [
       {
-        title: "Brief & objectifs",
-        description: "Atelier éditorial pour prioriser vos campagnes, promos et piliers de contenu.",
-        aiUpgrade: "Audit performance social + recommandations de formats IA.",
+        name: "Pack Journée",
+        price: "450–650 € HT",
+        description: "Tournage 1/2 journée, montage 45–60 s + photos détails",
       },
       {
-        title: "Scénario & planning",
-        description: "Scripts hooks, plan de tournage batch et pré-production logistique.",
-        aiUpgrade: "Générateur de variations de scripts pour A/B testing.",
+        name: "Pack Weekend",
+        price: "750–950 € HT",
+        description: "2 jours (jour + golden hour), montage 90 s + version verticale + 10 photos",
       },
       {
-        title: "Production agile",
-        description: "Tournages 1/2 journée, B-roll snack, captation audio autonome.",
-        aiUpgrade: "Sélection automatique des meilleures prises et cadrages.",
-      },
-      {
-        title: "Montage & révisions",
-        description: "Montage rapide, sous-titres animés, habillage motion réutilisable.",
-        aiUpgrade: "Templates dynamiques et suggestions de cuts pour chaque plateforme.",
-      },
-      {
-        title: "Pilotage",
-        description: "Livraison hebdo, bibliothèque Notion, reporting mensuel détaillé.",
-        aiUpgrade: "Dashboards automatisés avec idées de posts à venir.",
+        name: "Pack Sur Demande",
+        price: "Sur devis",
+        description: "Campagne multi-biens, voice-over, plans drone étendus",
       },
     ],
-    signatureMove: "Réunion éditoriale mensuelle + livraison des contenus prêts à programmer sous 48 h.",
-    metrics: [
-      { label: "Preuve", value: "+120%", note: "de vues sur 60 jours" },
-      { label: "Cadence", value: "8–16", note: "vidéos verticales / mois" },
-      { label: "Abonnement", value: "890 €", note: "HT / mois dès" },
-    ],
+    ctaLabel: "Mettre votre bien en valeur",
+    ctaSubcopy: "Créneau sous 72 h possible.",
   },
-
-  /* -------------------------------------------------- */
-  /* 5) MARIAGE                                         */
-  /* -------------------------------------------------- */
   {
     slug: "mariage",
-    title: "Film de mariage — vivant, élégant, fidèle à vous",
-    subtitle: "Un film que vous aurez plaisir à revoir et partager.",
-    hook: "Un film sincère, vivant, pour revivre l’émotion sans longueur.",
-    problem:
-      "Vous voulez revivre votre journée sans longueurs ni artifices, avec vos proches au centre.",
-    promise:
-      "Je capture chaque instant avec discrétion et livre un film sincère accompagné d’un teaser rapide et d’une galerie privée.",
-    stack: ["Sony A1", "Leica Q3", "Kodak Super 8", "Sora Colorist"],
-    deliverables: ["Film 5–8 minutes", "Bande-annonce 60 s", "Discours & moments bonus + galerie privée"],
-    timeline: "3–6 semaines",
-    startingPrice: "À partir de 1 900 € TTC",
-    proof: "97 % des couples recommandent",
-    ctaLabel: "Voir le service Mariage",
-    phases: [
+    name: "Film de mariage",
+    title: "Film de mariage — un souvenir vivant, sobre et élégant",
+    subtitle:
+      "Je raconte votre journée avec discrétion : de vrais moments, des émotions sincères, une esthétique lumineuse et naturelle.",
+    description: "Un film authentique, naturel et élégant de votre journée.",
+    timeline: "1er montage sous 3–4 semaines",
+    startingPrice: "À partir de 1 600 € TTC",
+    benefits: [
+      "Style documentaire ciné, couleurs douces",
+      "Prise de son des vœux & discours",
+      "Montage rythmé par votre énergie",
+    ],
+    formats: [
+      { title: "Formule Cœur", description: "Préparatifs → ouverture de bal, film 4–6 min" },
+      { title: "Formule Signature", description: "Préparatifs → 1 h du matin, film 6–8 min + teaser 60–90 s" },
+      { title: "Options", description: "Second shooter, drone, discours intégral, livraison express, clé USB souvenir" },
+    ],
+    workflow: {
+      preprod: [
+        "Appel découverte pour raconter votre histoire",
+        "Feuille de route avec moments clés, timings, playlists",
+      ],
+      production: [
+        "Présence discrète préparatifs → soirée, captation multi-cam des discours",
+        "Audio de secours et micros cravates pour vœux + cérémonies",
+      ],
+      postprod: [
+        "Montage cinématique 4–6 min, étalonnage doux",
+        "Sélection musique sous licence + teaser vertical",
+      ],
+      delivery: [
+        "Film 4K + 1080p, teaser vertical",
+        "Galerie privée protégée + clé USB optionnelle",
+      ],
+    },
+    process: [
+      { title: "Appel découverte", description: "On définit votre histoire et vos envies" },
+      { title: "Feuille de route", description: "Organisation des moments clés" },
+      { title: "Tournage discret", description: "Présence continue, captation son dédiée" },
+      { title: "Montage émotion", description: "Sélection musique sous licence, narration sincère" },
+      { title: "Livraison", description: "Film + teaser vertical, galerie privée" },
+    ],
+    deliverables: [
+      "Film en 4K + 1080p",
+      "Teaser vertical",
+      "Bande-son sous licence",
+      "Galerie privée en ligne",
+    ],
+    options: ["Second shooter", "Drone", "Discours intégral", "Livraison express", "Clé USB souvenir"],
+    pricing: [
       {
-        title: "Brief & objectifs",
-        description: "Rencontre vidéo, intentions artistiques, planning avec le wedding planner.",
-        aiUpgrade: "Moodboard émotionnel généré à partir de vos inspirations.",
+        name: "Pack Journée",
+        price: "1 600–2 000 € TTC",
+        description: "12 h de présence, film 4–6 min + teaser vertical",
       },
       {
-        title: "Scénario & planning",
-        description: "Storyline de la journée, repérages, coordination prestataires.",
-        aiUpgrade: "Assistant planning pour anticiper les moments clés et la lumière.",
+        name: "Pack Weekend",
+        price: "2 200–2 800 € TTC",
+        description: "2 jours (cérémonie civile + religieux), film 6–8 min + discours intégral",
       },
       {
-        title: "Tournage",
-        description: "Captation discrète, audio haute fidélité, séquences super 8 en option.",
-        aiUpgrade: "Focus tracking pour ne manquer aucun visage important.",
-      },
-      {
-        title: "Montage & révisions",
-        description: "Montage narratif, musique licenciée, 1 aller-retour inclus.",
-        aiUpgrade: "Sélection musicale assistée par IA validée avec vous.",
-      },
-      {
-        title: "Livraison",
-        description: "Bande-annonce J+7, film final 3–6 semaines, coffret souvenir.",
-        aiUpgrade: "Galerie privée sécurisée + backup 12 mois.",
+        name: "Pack Sur Demande",
+        price: "Sur devis",
+        description: "Destination wedding, second shooter, drone, livraison express",
       },
     ],
-    signatureMove: "Teaser livré sous 7 jours pour annoncer votre film complet.",
-    metrics: [
-      { label: "Preuve", value: "97%", note: "des couples recommandent" },
-      { label: "Délais", value: "3–6 sem.", note: "selon saison" },
-      { label: "Présence", value: "14 h", note: "de couverture continue" },
-    ],
+    ctaLabel: "Vérifier ma disponibilité",
+    ctaSubcopy: "Réponse sous 24 h, acompte pour bloquer la date.",
   },
-
-  /* -------------------------------------------------- */
-  /* 6) MOTION DESIGN / IA                              */
-  /* -------------------------------------------------- */
   {
-    slug: "motion-design-ia",
-    title: "Motion design / IA — rendez l’abstrait évident",
-    subtitle: "On comprend vite, on retient mieux, on agit plus.",
-    hook: "Expliquez l’invisible : process, produit tech, data — simplement.",
-    problem:
-      "Vos process tech ou data sont difficiles à expliquer sans support visuel pédagogique.",
-    promise:
-      "Je combine motion 2D/3D, avatars génératifs et sound design immersif pour vulgariser vos innovations et déclencher l’action.",
-    stack: ["After Effects 2025", "Blender Geo Nodes", "Runway Gen-3", "ElevenLabs Dubbing"],
-    deliverables: ["Vidéo 45–90 s animée", "Déclinaisons 30 s et 15 s", "Kit illustrations & loops UI"],
-    timeline: "2–4 semaines",
-    startingPrice: "À partir de 2 400 € HT",
-    proof: "+32 % de taux de complétion",
-    ctaLabel: "Voir le service Motion design/IA",
-    phases: [
+    slug: "reseaux-sociaux",
+    name: "Vidéos réseaux sociaux",
+    title: "Capsules social-first — verticales, ads et séries éditoriales",
+    subtitle:
+      "Du snack content aux campagnes ads, je produis des séries verticales pensées pour TikTok, Instagram, YouTube Shorts et LinkedIn avec un mix tournage + IA générative.",
+    description: "Capsules verticales, ads UGC, séries éditoriales.",
+    timeline: "Livraison 3 à 5 jours ouvrés après tournage",
+    startingPrice: "À partir de 650 € HT",
+    benefits: [
+      "Formats nativement pensés vertical/son-off",
+      "Calendrier éditorial & scripts optimisés conversion",
+      "Optimisation multi-plateformes + variations IA",
+    ],
+    formats: [
+      { title: "Capsules 15–30 s", description: "Pitch produit, tips, tutoriels punchy" },
+      { title: "Série éditoriale", description: "3 à 6 épisodes pour installer une rubrique" },
+      { title: "Ads UGC hybrides", description: "Tournage + IA pour déclinaisons ciblées" },
+      { title: "Live recap vertical", description: "Moments forts montés en 24 h" },
+    ],
+    workflow: {
+      preprod: [
+        "Sprint éditorial (message, hook, CTA, format)",
+        "Moodboard, scripts courts, templates brandés",
+      ],
+      production: [
+        "Tournage en rafale (studio ou in situ) + captation B-roll",
+        "Captation mobile/FPV si besoin pour un rendu organique",
+      ],
+      postprod: [
+        "Montage motion punchy, sous-titres dynamiques, versions son-off",
+        "Déclinaisons IA (variations visuelles, langues, accroches)",
+      ],
+      delivery: [
+        "Lots exportés par plateforme (9:16, 1:1, 4:5)",
+        "Planification recommandée + scripts de publication",
+      ],
+    },
+    process: [
+      { title: "Atelier éditorial", description: "Hooks, messages, calendrier" },
+      { title: "Pré-prod agile", description: "Scripts, moodboard, templates" },
+      { title: "Tournage batch", description: "1 à 2 journées, multi-sets" },
+      { title: "Montage & déclinaisons", description: "Motion dynamique, variations IA" },
+      { title: "Livraison & planif", description: "Exports optimisés + kit diffusion" },
+    ],
+    deliverables: [
+      "Capsules verticales 9:16 + versions carrées",
+      "Sous-titres dynamiques + fichiers .srt",
+      "Thumbs/midjourney prompts pour visuels de couverture",
+    ],
+    options: [
+      "Pack templates Canva/After Effects",
+      "Voix-off IA multilingue",
+      "Pilotage Ads + reporting",
+    ],
+    pricing: [
       {
-        title: "Brief & objectifs",
-        description: "Atelier storytelling produit, identification des messages clés et KPI.",
-        aiUpgrade: "Mindmap IA pour clarifier les parcours utilisateurs et objections.",
+        name: "Pack Journée",
+        price: "750–1 050 € HT",
+        description: "1 journée tournage batch, 4 capsules montées + déclinaison IA",
       },
       {
-        title: "Scénario & planning",
-        description: "Script, storyboard illustré, moodboard design et charte motion.",
-        aiUpgrade: "Animatics génératifs + voix témoin pour valider rythme.",
+        name: "Pack Weekend",
+        price: "1 400–1 900 € HT",
+        description: "2 jours (studio + terrain), 8 capsules + 2 ads UGC",
       },
       {
-        title: "Production",
-        description: "Animation 2D/3D, simulations data, intégration UI et avatars.",
-        aiUpgrade: "Textures génératives et avatars IA pilotés sur mesure.",
-      },
-      {
-        title: "Montage & révisions",
-        description: "Sound design, mixage multilingue, itérations ciblées.",
-        aiUpgrade: "Traductions et doublages IA validés par relecture humaine.",
-      },
-      {
-        title: "Activation",
-        description: "Exports webinaire, landing page, réseaux sociaux + toolkit brand.",
-        aiUpgrade: "Check-list accessibilité + QA automatique des contrastes.",
+        name: "Pack Sur Demande",
+        price: "Sur devis",
+        description: "Calendrier mensuel 12+ vidéos, automatisations IA & reporting",
       },
     ],
-    signatureMove: "Version multilingue (FR/EN/ES) incluse grâce au pipeline de doublage IA.",
-    metrics: [
-      { label: "Preuve", value: "+32%", note: "de taux de complétion" },
-      { label: "Délais", value: "2–4 sem.", note: "selon complexité" },
-      { label: "Formats", value: "3", note: "durées livrées (90/30/15 s)" },
+    ctaLabel: "Doper vos réseaux",
+    ctaSubcopy: "On cale les hooks et la diffusion en moins de 48 h.",
+  },
+  {
+    slug: "motion-ia",
+    name: "Motion Design / IA",
+    title: "Motion design & IA — expériences hybrides, volumétriques et génératives",
+    subtitle:
+      "Associez motion design premium, 3D légère et IA générative (Runway, Sora, ElevenLabs) pour produire des contenus futuristes, pédagogiques ou immersifs.",
+    description: "Motion design, IA générative, expériences volumétriques.",
+    timeline: "Planning 4 à 6 semaines selon complexité",
+    startingPrice: "À partir de 1 800 € HT",
+    benefits: [
+      "Narration pédagogique + direction artistique futuriste",
+      "Assets IA générés sous supervision créative",
+      "Livrables multi-formats (16:9, 1:1, 9:16, volumétrique)",
     ],
+    formats: [
+      { title: "Reveal produit", description: "Teaser motion + effets génératifs" },
+      { title: "Explainer animé", description: "Storyboard, illustrations, voice-over IA" },
+      { title: "Boucles volumétriques", description: "Objets 3D / NeRF animés pour stands & AR" },
+      { title: "Pack lancement", description: "Manifesto + déclinaisons social + gifs" },
+    ],
+    workflow: {
+      preprod: [
+        "Discovery workshop, moodboard, script + storyboard",
+        "Design system motion + prompts IA validés",
+      ],
+      production: [
+        "Illustrations, modélisation légère, tournage éléments si besoin",
+        "Générations IA (vidéo, voix, textures) sous contrôle direction artistique",
+      ],
+      postprod: [
+        "Animation, compositing, sound design immersif",
+        "Versions adaptées par canal (web, réseaux, events)",
+      ],
+      delivery: [
+        "Exports 4K, 1080p, 9:16, gifs animés",
+        "Sources projet + guide d’utilisation",
+      ],
+    },
+    process: [
+      { title: "Discovery & script", description: "Objectifs, message clé, moodboard" },
+      { title: "Storyboard & design", description: "Styleframes, charte motion, prompts IA" },
+      { title: "Production hybride", description: "Animation, tournage éléments, IA supervisée" },
+      { title: "Post-production", description: "Compositing, sound design, QA" },
+      { title: "Livraison & déclinaisons", description: "Exports multi-formats + kit templates" },
+    ],
+    deliverables: [
+      "Vidéo principale (4K/1080p)",
+      "Déclinaisons verticales + boucles sociales",
+      "Pack assets (illustrations, sous-titres, templates)",
+    ],
+    options: [
+      "Voix-off native + IA",
+      "Pack AR/WebGL",
+      "Localisations multilingues",
+    ],
+    pricing: [
+      {
+        name: "Pack Journée",
+        price: "1 800–2 400 € HT",
+        description: "Sprint motion 16:9 + déclinaison verticale (1 semaine)",
+      },
+      {
+        name: "Pack Weekend",
+        price: "3 200–4 200 € HT",
+        description: "2 semaines : reveal produit + kit social + sound design",
+      },
+      {
+        name: "Pack Sur Demande",
+        price: "Sur devis",
+        description: "Campagne complète 4-6 semaines, volumétrique & localisations",
+      },
+    ],
+    ctaLabel: "Imaginer un format hybride",
+    ctaSubcopy: "Workshop créatif offert pour cadrer le concept.",
   },
 ];
 
+export const methodSteps = [
+  { title: "Brief clair", description: "Objectifs, audience, style, canaux" },
+  { title: "Préparation simple", description: "Script/plan de tournage, repérages, feuille de route" },
+  { title: "Tournage léger", description: "Lumière & son pro, direction naturelle" },
+  { title: "Montage soigné", description: "Rythme, musique/licences, étalonnage" },
+  { title: "Livraison multi-formats", description: "Formats web, réseaux, sous-titres, corrections incluses" },
+];
+
+export const testimonials = [
+  {
+    quote: "Une vidéo qui a doublé notre taux de conversion sur la page d’accueil.",
+    author: "Client Entreprise",
+  },
+  {
+    quote: "Aftermovie livré en 72 h, parfait pour notre recap LinkedIn.",
+    author: "Organisateur de salon",
+  },
+];

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -63,7 +63,7 @@ const About = () => {
             </div>
             <div className="flex flex-wrap gap-4">
               <Link
-                to="/realisations"
+                to="/portfolio"
                 className="inline-flex items-center gap-3 rounded-full border border-white/20 bg-white/10 px-6 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/15"
               >
                 Voir le showreel
@@ -140,10 +140,10 @@ const About = () => {
         <section className="space-y-6">
           <h2 className="text-3xl font-extrabold">Services phares</h2>
           <div className="grid gap-6 lg:grid-cols-2">
-            {servicesData.slice(0, 4).map((service) => (
+            {servicesData.map((service) => (
               <article key={service.slug} className="rounded-[2.5rem] border border-white/10 bg-slate-900/60 p-6">
                 <p className="text-[0.65rem] font-semibold uppercase tracking-[0.45em] text-white/60">{service.slug.replace(/-/g, " ")}</p>
-                <h3 className="mt-3 text-2xl font-semibold text-white">{service.title}</h3>
+                <h3 className="mt-3 text-2xl font-semibold text-white">{service.name}</h3>
                 <p className="mt-3 text-sm text-white/70">{service.subtitle}</p>
                 <Link to={`/services/${service.slug}`} className="mt-5 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.35em] text-sky-200">
                   Voir le détail

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -81,8 +81,8 @@ const Index = () => {
     () =>
       servicesData.map((service) => ({
         slug: service.slug,
-        title: service.title,
-        hook: service.hook,
+        title: service.name,
+        intro: service.description,
         timeline: service.timeline,
         startingPrice: service.startingPrice,
         deliverables: service.deliverables.slice(0, 2),
@@ -159,7 +159,7 @@ const Index = () => {
                   Programmer un appel créatif
                 </Link>
                 <Link
-                  to="/realisations"
+                  to="/portfolio"
                   className="inline-flex items-center gap-3 rounded-full border border-white/30 px-8 py-4 text-sm font-bold uppercase tracking-[0.35em] text-white/70 transition-colors duration-300 hover:text-white"
                 >
                   Voir le showreel
@@ -197,7 +197,7 @@ const Index = () => {
                       <p className="text-sm font-semibold text-white">{heroProject?.title ?? "Studio VBG"}</p>
                     </div>
                     <Link
-                      to="/realisations"
+                      to="/portfolio"
                       className="inline-flex items-center gap-2 rounded-full border border-white/30 bg-white/10 px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-white"
                     >
                       Lecture
@@ -230,7 +230,7 @@ const Index = () => {
               </p>
             </div>
             <Link
-              to="/realisations"
+              to="/portfolio"
               className="inline-flex items-center gap-3 rounded-full border border-white/20 bg-white/10 px-6 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/15"
             >
               Découvrir le portfolio complet
@@ -283,7 +283,7 @@ const Index = () => {
                   <span>{service.startingPrice}</span>
                 </div>
                 <h3 className="text-xl font-semibold text-white">{service.title}</h3>
-                <p className="text-sm text-white/70">{service.hook}</p>
+                <p className="text-sm text-white/70">{service.intro}</p>
                 <ul className="space-y-2 text-sm text-white/60">
                   {service.deliverables.map((item) => (
                     <li key={item} className="flex items-start gap-2">

--- a/src/pages/Portfolio.tsx
+++ b/src/pages/Portfolio.tsx
@@ -99,7 +99,7 @@ const Portfolio = () => {
 
     const label = slugToLabel.get(categorySlug);
     if (!label) {
-      navigate("/realisations", { replace: true });
+      navigate("/portfolio", { replace: true });
       return;
     }
 
@@ -115,12 +115,12 @@ const Portfolio = () => {
   const handleCategoryChange = (category: string) => {
     setActiveCategory(category);
     if (category === ALL_CATEGORY) {
-      navigate("/realisations");
+      navigate("/portfolio");
       return;
     }
 
     const slug = labelToSlug.get(category);
-    navigate(slug ? `/realisations/${slug}` : "/realisations");
+    navigate(slug ? `/portfolio/${slug}` : "/portfolio");
   };
 
   const filteredItems = useMemo(() => {
@@ -380,19 +380,18 @@ const Portfolio = () => {
             <div className="space-y-4">
               <p className="text-xs font-semibold uppercase tracking-[0.35em] text-white/60">Processus / Méthode</p>
               <h2 className="text-3xl font-bold text-white">
-                {activeService ? `Workflow ${activeService.title}` : "Une méthode fluide pour chaque catégorie"}
+                {activeService ? `Workflow ${activeService.name}` : "Une méthode fluide pour chaque catégorie"}
               </h2>
               <p className="text-sm text-white/70">
                 Chaque tournage est encadré par un chef de projet unique, un plan de repérage, un pipeline IA supervisé et un plan de diffusion multi-format. Voici le déroulé que nous appliquons à vos réalisations.
               </p>
             </div>
             <div className="space-y-4 rounded-[2.5rem] border border-white/10 bg-slate-950/60 p-6">
-              {(activeService?.phases ?? servicesData[0].phases).slice(0, 4).map((phase, index) => (
+              {(activeService?.process ?? servicesData[0].process).slice(0, 4).map((phase, index) => (
                 <div key={phase.title} className="flex flex-col gap-2 rounded-[2rem] border border-white/10 bg-white/5 p-4 text-sm text-white/70">
                   <span className="text-[0.6rem] font-semibold uppercase tracking-[0.35em] text-white/50">Étape 0{index + 1}</span>
                   <p className="text-sm text-white">{phase.title}</p>
                   <p>{phase.description}</p>
-                  <p className="text-xs text-sky-200/80">Upgrade IA : {phase.aiUpgrade}</p>
                 </div>
               ))}
             </div>

--- a/src/pages/ServiceDetail.tsx
+++ b/src/pages/ServiceDetail.tsx
@@ -1,5 +1,6 @@
 import { Link, useParams } from "react-router-dom";
-import { servicesData } from "@/lib/services";
+
+import { methodSteps, servicesData } from "@/lib/services";
 
 const ServiceDetail = () => {
   const { slug } = useParams();
@@ -23,88 +24,193 @@ const ServiceDetail = () => {
         className="pointer-events-none absolute inset-0"
         style={{
           background:
-            "conic-gradient(from 120deg at 20% 20%, hsla(var(--visual-accent)/0.25), hsla(var(--visual-secondary)/0.18), transparent 70%)",
+            "conic-gradient(from 120deg at 20% 20%, hsla(var(--visual-accent, 190 95% 62%)/0.25), hsla(var(--visual-secondary, 286 74% 63%)/0.18), transparent 70%)",
         }}
       />
-      <div className="relative mx-auto max-w-6xl px-6 pb-24 pt-16">
+      <div className="relative mx-auto flex w-full max-w-6xl flex-col gap-16 px-6 pb-24 pt-16 sm:px-10">
         <header className="rounded-[3rem] border border-white/10 bg-white/5 p-12 shadow-[0_20px_120px_rgba(34,211,238,0.2)] visual-accent-veil">
           <div className="flex flex-col gap-10 lg:flex-row lg:items-end lg:justify-between">
             <div className="space-y-6">
               <span className="inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.35em] text-cyan-100/80 visual-accent-text-strong">
-                Module Studio VBG
+                {service.name}
               </span>
-              <h1 className="text-5xl font-black">{service.title}</h1>
-              <p className="text-lg text-slate-200/80">{service.subtitle}</p>
+              <div className="space-y-4">
+                <h1 className="text-5xl font-black">{service.title}</h1>
+                <p className="max-w-2xl text-lg text-slate-200/85">{service.subtitle}</p>
+              </div>
+              <div className="flex flex-wrap gap-6 text-sm text-slate-200/70">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.35em] text-cyan-200/80">À partir de</p>
+                  <p className="mt-2 text-xl font-semibold text-white">{service.startingPrice}</p>
+                </div>
+                <div>
+                  <p className="text-xs uppercase tracking-[0.35em] text-cyan-200/80">Timeline</p>
+                  <p className="mt-2 text-xl font-semibold text-white">{service.timeline}</p>
+                </div>
+              </div>
+              <div className="flex flex-wrap gap-4">
+                <Link to="/contact" className="rounded-full border border-cyan-200/40 visual-accent-border bg-cyan-500/20 visual-accent-bg px-6 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-white">
+                  {service.ctaLabel}
+                </Link>
+                <Link to="/services" className="rounded-full border border-white/20 bg-white/10 px-6 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-white/80 transition hover:bg-white/15">
+                  Revenir aux services
+                </Link>
+              </div>
             </div>
-            <div className="text-sm text-slate-200/70">
-              <p className="uppercase tracking-[0.3em] text-cyan-200/80 visual-accent-text">Point différenciant</p>
-              <p className="mt-2 text-lg text-white">{service.signatureMove}</p>
+            <div className="space-y-4 rounded-[2.5rem] border border-white/10 bg-slate-900/60 p-6 text-sm text-white/75">
+              <p className="text-xs uppercase tracking-[0.35em] text-white/60">Preuves & avantages</p>
+              <ul className="space-y-3">
+                {service.benefits.map((benefit) => (
+                  <li key={benefit} className="flex items-start gap-3">
+                    <span className="mt-1 h-2 w-2 rounded-full bg-cyan-300 visual-accent-dot" aria-hidden />
+                    <span>{benefit}</span>
+                  </li>
+                ))}
+              </ul>
             </div>
           </div>
         </header>
 
-        <section className="mt-16 grid gap-12 lg:grid-cols-[1.5fr_1fr]">
-          <div className="space-y-10">
-            <div className="rounded-[2.5rem] border border-white/10 bg-white/5 p-10 shadow-[0_15px_80px_rgba(14,165,233,0.2)] visual-accent-glow">
-              <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Narration</p>
-              <p className="mt-4 text-lg leading-relaxed text-slate-200/80">{service.promise}</p>
+        <section className="grid gap-10 lg:grid-cols-[1.4fr_1fr]">
+          <div className="space-y-8">
+            <div className="rounded-[2.5rem] border border-white/10 bg-white/5 p-8 shadow-[0_15px_80px_rgba(14,165,233,0.2)] visual-accent-glow">
+              <p className="text-xs uppercase tracking-[0.35em] text-cyan-200/70 visual-accent-text">Formats proposés</p>
+              <ul className="mt-4 space-y-4 text-sm text-slate-200/85">
+                {service.formats.map((format) => (
+                  <li key={format.title} className="rounded-[2rem] border border-white/10 bg-slate-950/60 p-4">
+                    <p className="text-sm font-semibold text-white">{format.title}</p>
+                    <p className="mt-1 text-sm text-white/75">{format.description}</p>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div className="space-y-4 rounded-[2.5rem] border border-white/10 bg-white/5 p-8">
+              <div className="flex items-center justify-between gap-6">
+                <h2 className="text-3xl font-bold text-white">Essentiel du déroulement</h2>
+                <p className="text-xs uppercase tracking-[0.35em] text-white/60">Préprod → Livrables</p>
+              </div>
+              <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                {(
+                  [
+                    { label: "Préprod", steps: service.workflow.preprod },
+                    { label: "Prod", steps: service.workflow.production },
+                    { label: "Postprod", steps: service.workflow.postprod },
+                    { label: "Livrables", steps: service.workflow.delivery },
+                  ] as const
+                ).map((block) => (
+                  <div key={block.label} className="rounded-[2rem] border border-white/10 bg-slate-950/60 p-5">
+                    <p className="text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-white/55">{block.label}</p>
+                    <ul className="mt-3 space-y-2 text-sm text-white/75">
+                      {block.steps.map((item) => (
+                        <li key={item} className="flex items-start gap-2">
+                          <span className="mt-1 h-1.5 w-1.5 rounded-full bg-cyan-300 visual-accent-dot" aria-hidden />
+                          <span>{item}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
             </div>
             <div className="space-y-6">
-              {service.phases.map((phase, index) => (
-                <div
-                  key={phase.title}
-                  className="group relative overflow-hidden rounded-[2.5rem] border border-white/10 bg-gradient-to-br from-white/10 to-white/5 p-8 shadow-[0_20px_90px_rgba(236,72,153,0.18)] visual-secondary-veil"
-                >
-                  <span className="absolute inset-0 translate-y-full bg-gradient-to-t from-fuchsia-500/20 via-transparent to-transparent transition-transform duration-700 group-hover:translate-y-0" />
-                  <div className="relative space-y-4">
-                    <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-slate-200/70">
-                      <span>Phase 0{index + 1}</span>
-                      <span>{phase.aiUpgrade}</span>
-                    </div>
-                    <h2 className="text-2xl font-bold">{phase.title}</h2>
-                    <p className="text-sm text-slate-200/80">{phase.description}</p>
-                  </div>
-                </div>
-              ))}
+              <div className="flex items-center justify-between gap-6">
+                <h2 className="text-3xl font-bold text-white">Processus</h2>
+                <p className="text-xs uppercase tracking-[0.35em] text-white/60">Étapes clés</p>
+              </div>
+              <ol className="grid gap-4 md:grid-cols-2">
+                {service.process.map((phase, index) => (
+                  <li key={phase.title} className="rounded-[2.5rem] border border-white/10 bg-slate-900/60 p-6">
+                    <p className="text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-white/50">Étape 0{index + 1}</p>
+                    <p className="mt-3 text-lg font-semibold text-white">{phase.title}</p>
+                    <p className="mt-2 text-sm text-white/75">{phase.description}</p>
+                  </li>
+                ))}
+              </ol>
             </div>
           </div>
           <aside className="space-y-8">
             <div className="rounded-[2.5rem] border border-white/10 bg-white/5 p-8">
-              <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Livrables inclus</p>
+              <p className="text-xs uppercase tracking-[0.35em] text-cyan-200/70 visual-accent-text">Livrables inclus</p>
               <ul className="mt-4 space-y-3 text-sm text-slate-200/80">
                 {service.deliverables.map((item) => (
                   <li key={item} className="flex items-start gap-3">
-                    <span className="mt-1 h-2 w-2 rounded-full bg-cyan-300 visual-accent-dot" />
+                    <span className="mt-1 h-2 w-2 rounded-full bg-cyan-300 visual-accent-dot" aria-hidden />
                     <span>{item}</span>
                   </li>
                 ))}
               </ul>
             </div>
-            <div className="rounded-[2.5rem] border border-white/10 bg-white/5 p-8">
-              <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Chiffres clés</p>
-              <ul className="mt-4 space-y-4 text-sm text-slate-200/80">
-                {service.metrics.map((metric) => (
-                  <li key={metric.label} className="rounded-2xl bg-slate-900/60 p-4">
-                    <p className="text-xs uppercase tracking-[0.3em] text-slate-200/60">{metric.label}</p>
-                    <p className="mt-2 text-2xl font-bold text-cyan-200 visual-accent-text">{metric.value}</p>
-                    <p className="text-xs text-slate-200/60">{metric.note}</p>
-                  </li>
-                ))}
-              </ul>
-            </div>
-            <div className="rounded-[2.5rem] border border-white/10 bg-white/5 p-8 text-sm text-slate-200/80">
-              <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/70 visual-accent-text">Étape suivante</p>
-              <p className="mt-4">Intéressé par ce module ? Connectez-vous, demandez un devis et nous lançons la préproduction.</p>
-              <div className="mt-6 flex flex-col gap-3">
-                <Link to="/auth" className="rounded-full border border-white/30 bg-white/10 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white">
-                  Me connecter
-                </Link>
-                <Link to="/quote" className="rounded-full border border-cyan-200/40 visual-accent-border bg-cyan-500/20 visual-accent-bg px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white">
-                  Demander un devis
-                </Link>
+            {service.options?.length ? (
+              <div className="rounded-[2.5rem] border border-white/10 bg-white/5 p-8">
+                <p className="text-xs uppercase tracking-[0.35em] text-cyan-200/70 visual-accent-text">Options</p>
+                <ul className="mt-4 space-y-2 text-sm text-slate-200/80">
+                  {service.options.map((option) => (
+                    <li key={option} className="flex items-start gap-3">
+                      <span className="mt-1 h-2 w-2 rounded-full bg-fuchsia-300 visual-secondary-dot" aria-hidden />
+                      <span>{option}</span>
+                    </li>
+                  ))}
+                </ul>
               </div>
+            ) : null}
+            <div className="rounded-[2.5rem] border border-white/10 bg-white/5 p-8 text-sm text-slate-200/80">
+              <p className="text-xs uppercase tracking-[0.35em] text-cyan-200/70 visual-accent-text">Prêt à démarrer ?</p>
+              <p className="mt-3 text-white/85">{service.ctaSubcopy}</p>
+              <Link to="/contact" className="mt-5 inline-flex items-center gap-3 rounded-full border border-cyan-200/40 visual-accent-border bg-cyan-500/20 visual-accent-bg px-5 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-white">
+                {service.ctaLabel}
+              </Link>
             </div>
           </aside>
+        </section>
+
+        <section className="space-y-6">
+          <h2 className="text-3xl font-bold text-white">Tarifs indicatifs</h2>
+          <div className="grid gap-6 lg:grid-cols-3">
+            {service.pricing.map((pack) => (
+              <div key={pack.name} className="rounded-[2.5rem] border border-white/10 bg-white/5 p-8">
+                <p className="text-xs font-semibold uppercase tracking-[0.35em] text-white/60">{pack.name}</p>
+                <p className="mt-3 text-2xl font-bold text-white">{pack.price}</p>
+                <p className="mt-2 text-sm text-white/75">{pack.description}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="rounded-[3rem] border border-white/10 bg-gradient-to-br from-sky-500/20 via-indigo-500/20 to-fuchsia-500/20 p-10 text-sm text-white/80 backdrop-blur-2xl">
+          <div className="space-y-4">
+            <h2 className="text-3xl font-bold text-white">{service.ctaLabel}</h2>
+            <p>{service.ctaSubcopy}</p>
+            <p className="text-white/70">Réponse sous 24 h ouvrées. Devis gratuit et sans engagement.</p>
+          </div>
+          <div className="mt-6 flex flex-wrap gap-4">
+            <Link to="/contact" className="rounded-full border border-white/30 bg-white/10 px-6 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/15">
+              Demander un devis
+            </Link>
+            <Link to="/contact" className="rounded-full border border-white/20 bg-transparent px-6 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-white/70 transition hover:text-white">
+              Poser une question
+            </Link>
+          </div>
+        </section>
+
+        <section className="rounded-[3rem] border border-white/10 bg-white/5 p-10 text-sm text-white/75 backdrop-blur-2xl">
+          <h2 className="text-3xl font-bold text-white">Questions budgétaires & pratiques</h2>
+          <p className="mt-4">
+            Droits musicaux, révisions, délais précis, formats de livraison ou conditions de déplacement sont détaillés dans la <Link to="/blog" className="underline decoration-dotted decoration-white/50 underline-offset-4">FAQ budgétaire du blog</Link>. Vous pouvez aussi ajouter vos questions dans le formulaire de contact.
+          </p>
+        </section>
+
+        <section className="rounded-[3rem] border border-white/10 bg-white/5 p-10 backdrop-blur-2xl">
+          <h2 className="text-3xl font-bold text-white">Méthode Studio VBG</h2>
+          <p className="mt-3 text-sm text-white/70">Brief clair → Préparation simple → Tournage léger → Montage soigné → Livraison multi-formats.</p>
+          <ol className="mt-6 grid gap-4 lg:grid-cols-5">
+            {methodSteps.map((step, index) => (
+              <li key={step.title} className="rounded-[2.5rem] border border-white/10 bg-slate-950/60 p-6">
+                <p className="text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-white/50">Étape 0{index + 1}</p>
+                <p className="mt-3 text-lg font-semibold text-white">{step.title}</p>
+                <p className="mt-2 text-sm text-white/70">{step.description}</p>
+              </li>
+            ))}
+          </ol>
         </section>
       </div>
     </div>

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -1,137 +1,7 @@
 import { useMemo } from "react";
 import { Link } from "react-router-dom";
 
-import { CATEGORIES } from "@/components/header/nav.config";
-import { servicesData } from "@/lib/services";
-
-const heroHighlights = [
-  { label: "Stack 2025", value: "Burano 8K + Gen-5", note: "Workflow hybride IA & humain" },
-  { label: "Délais", value: "72 h – 5 sem.", note: "selon complexité & diffusion" },
-  { label: "Satisfaction", value: "4,9/5", note: "Avis clients vérifiés" },
-];
-
-const servicePacks: Record<string, { name: string; description: string; price: string; includes: string[] }[]> = {
-  entreprise: [
-    {
-      name: "Pack Journée",
-      description: "1 jour de tournage multicam + interviews", 
-      price: "À partir de 1 900 € HT",
-      includes: ["Film 60–90 s", "2 teasers 9:16", "Sous-titres FR/EN"],
-    },
-    {
-      name: "Pack Weekend",
-      description: "2 jours (interviews + B-roll terrain)",
-      price: "Dès 2 900 € HT",
-      includes: ["Film 90 s", "4 capsules 15 s", "Miniatures brandées"],
-    },
-    {
-      name: "Pack Sur demande",
-      description: "Narration premium + captations multi-sites",
-      price: "Sur devis", 
-      includes: ["Script direction com.", "Version 1:1 et 9:16", "Plan diffusion clé en main"],
-    },
-  ],
-  evenementiel: [
-    {
-      name: "Pack Journée",
-      description: "Captation express 1 jour",
-      price: "À partir de 1 400 € HT",
-      includes: ["Aftermovie 60 s", "Stories verticales", "Livraison J+3"],
-    },
-    {
-      name: "Pack Weekend",
-      description: "2 jours d'événement",
-      price: "Dès 2 200 € HT",
-      includes: ["Aftermovie 90 s", "5 capsules sponsor", "Galerie photo optionnelle"],
-    },
-    {
-      name: "Pack Sur demande",
-      description: "Couverture complète + live clips",
-      price: "Sur devis",
-      includes: ["Highlights demi-journée", "Montage 24 h", "Kit médias partenaires"],
-    },
-  ],
-  immobilier: [
-    {
-      name: "Pack Journée",
-      description: "Visite 4K HDR",
-      price: "À partir de 650 € HT",
-      includes: ["Film 60 s", "Version 9:16", "Photos HDR option"],
-    },
-    {
-      name: "Pack Weekend",
-      description: "2 biens ou biens premium",
-      price: "Dès 1 150 € HT",
-      includes: ["Plans drone", "Titres quartiers", "Miniatures agence"],
-    },
-    {
-      name: "Pack Sur demande",
-      description: "Programme neuf / luxe",
-      price: "Sur devis",
-      includes: ["Interviews promoteur", "Version ADS", "Visite virtuelle option"],
-    },
-  ],
-  "reseaux-sociaux": [
-    {
-      name: "Pack Journée",
-      description: "Tournage batch 6 vidéos",
-      price: "À partir de 1 050 € HT",
-      includes: ["6 formats 9:16", "Scripts + prompts", "Sous-titres dynamiques"],
-    },
-    {
-      name: "Pack Weekend",
-      description: "Tournage 2 jours",
-      price: "Dès 1 850 € HT",
-      includes: ["12 vidéos 9:16", "Templates motion", "Planning publication"],
-    },
-    {
-      name: "Pack Sur demande",
-      description: "Programme 3 mois",
-      price: "Sur devis",
-      includes: ["16-24 vidéos/mois", "Dashboards KPI", "Coaching équipes"],
-    },
-  ],
-  mariage: [
-    {
-      name: "Pack Journée",
-      description: "Cérémonie + cocktail",
-      price: "À partir de 1 750 € TTC",
-      includes: ["Film 6-8 min", "Teaser 60 s", "Discours micro HF"],
-    },
-    {
-      name: "Pack Weekend",
-      description: "Préparatifs + jour J complet",
-      price: "Dès 2 450 € TTC",
-      includes: ["Film 10-12 min", "Clips réseaux", "Coffret USB"],
-    },
-    {
-      name: "Pack Sur demande",
-      description: "Destination / production élargie",
-      price: "Sur devis",
-      includes: ["Drone FPV", "Voix-off storytelling", "Montage express 72 h"],
-    },
-  ],
-  "motion-design-ia": [
-    {
-      name: "Pack Journée",
-      description: "Script + storyboard + animatic",
-      price: "À partir de 2 200 € HT",
-      includes: ["Vidéo 45 s", "Habillage sonore", "Illustrations personnalisées"],
-    },
-    {
-      name: "Pack Weekend",
-      description: "Motion + IA générative",
-      price: "Dès 3 200 € HT",
-      includes: ["Vidéo 60-75 s", "Version 9:16", "Titres multilingues"],
-    },
-    {
-      name: "Pack Sur demande",
-      description: "Série pédagogique / onboarding",
-      price: "Sur devis",
-      includes: ["3-5 épisodes", "Assistant IA voix", "Guide diffusion"],
-    },
-  ],
-};
+import { methodSteps, servicesData } from "@/lib/services";
 
 const Services = () => {
   const services = useMemo(() => servicesData, []);
@@ -143,177 +13,284 @@ const Services = () => {
         className="pointer-events-none absolute inset-0"
         style={{
           background:
-            "radial-gradient(circle at 20% 20%, rgba(56,189,248,0.28), transparent 55%), radial-gradient(circle at 80% 15%, rgba(147,51,234,0.18), transparent 60%), radial-gradient(circle at 50% 90%, rgba(236,72,153,0.2), transparent 65%)",
+            "radial-gradient(circle at 20% 20%, rgba(56,189,248,0.18), transparent 55%), radial-gradient(circle at 80% 0%, rgba(236,72,153,0.16), transparent 60%), radial-gradient(circle at 50% 90%, rgba(14,165,233,0.18), transparent 65%)",
         }}
       />
-      <div className="relative mx-auto max-w-6xl px-6 pb-32 pt-24 sm:px-10">
-        {/* HERO */}
-        <header className="relative overflow-hidden rounded-[3.5rem] border border-white/10 bg-white/[0.04] p-12 shadow-[0_40px_140px_rgba(14,165,233,0.28)] backdrop-blur-3xl">
-          <div aria-hidden className="absolute inset-0 -z-10">
-            <div className="absolute inset-0 animate-[spin_18s_linear_infinite] bg-[conic-gradient(from_180deg_at_50%_50%,rgba(125,211,252,0.15),rgba(244,114,182,0.1),rgba(14,165,233,0.25),transparent_65%)]" />
-            <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.18),transparent_60%)]" />
-          </div>
-          <div className="grid gap-12 lg:grid-cols-[1.5fr_1fr] lg:items-end">
-            <div className="space-y-10">
-              <span className="inline-flex items-center gap-3 rounded-full border border-cyan-200/30 bg-cyan-500/15 px-5 py-2 text-[0.7rem] font-semibold uppercase tracking-[0.35em] text-cyan-100/80">
-                Services & Tarifs · Septembre 2025
+
+      <div className="relative mx-auto flex w-full max-w-6xl flex-col gap-20 px-6 pb-32 pt-20 sm:px-10">
+        <header className="rounded-[3.5rem] border border-white/10 bg-slate-950/70 p-12 shadow-[0_30px_160px_rgba(56,189,248,0.28)] backdrop-blur-3xl">
+          <div className="grid gap-10 lg:grid-cols-[1.4fr_1fr] lg:items-end">
+            <div className="space-y-8">
+              <span className="inline-flex items-center gap-3 rounded-full border border-white/20 bg-white/10 px-5 py-2 text-[0.7rem] font-semibold uppercase tracking-[0.38em] text-white/70">
+                Services & Tarifs
               </span>
-              <div className="space-y-6">
+              <div className="space-y-5">
                 <h1 className="text-5xl font-black leading-tight md:text-6xl">
-                  Des offres packagées, pilotées et mesurables
+                  Des vidéos pro qui font grandir votre marque
                 </h1>
-                <p className="max-w-2xl text-lg text-slate-200/80">
-                  De l'idée au plan de diffusion, chaque service suit un pipeline préproduction → production → postproduction → activation. Vous choisissez le pack, nous orchestrons le reste.
+                <p className="max-w-2xl text-lg text-white/75">
+                  Vous imaginez, nous réalisons. Chez <strong>Studio VBG</strong>, nous concevons, organisons, tournons et montons des vidéos claires, belles et efficaces pour vos objectifs : entreprise, événementiel, immobilier, réseaux sociaux, mariage ou formats hybrides IA.
                 </p>
               </div>
               <div className="flex flex-wrap gap-4">
                 <Link
-                  to="/contact"
-                  className="group inline-flex items-center gap-3 rounded-full border border-cyan-200/40 bg-cyan-500/25 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white transition hover:bg-cyan-500/35"
+                  to="/contact?focus=devis"
+                  className="group inline-flex items-center gap-3 rounded-full bg-gradient-to-r from-sky-500 via-indigo-500 to-fuchsia-500 px-7 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-white shadow-[0_18px_80px_rgba(59,130,246,0.35)] transition hover:-translate-y-0.5"
                 >
                   Demander un devis
                   <span aria-hidden className="transition group-hover:translate-x-1">→</span>
                 </Link>
                 <Link
-                  to="/realisations"
-                  className="group inline-flex items-center gap-3 rounded-full border border-white/20 bg-white/10 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-white transition hover:bg-white/20"
+                  to="/portfolio"
+                  className="inline-flex items-center gap-3 rounded-full border border-white/20 bg-white/10 px-7 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-white/80 transition hover:bg-white/15 hover:text-white"
                 >
                   Voir des réalisations
-                  <span aria-hidden className="transition group-hover:translate-x-1">→</span>
                 </Link>
               </div>
-              <dl className="grid gap-6 sm:grid-cols-3">
-                {heroHighlights.map((item) => (
-                  <div key={item.label} className="rounded-3xl border border-white/10 bg-white/10 p-6 backdrop-blur-xl">
-                    <dt className="text-xs uppercase tracking-[0.3em] text-cyan-200/70">{item.label}</dt>
-                    <dd className="mt-3 text-2xl font-bold">{item.value}</dd>
-                    <p className="text-xs text-slate-200/70">{item.note}</p>
-                  </div>
-                ))}
-              </dl>
             </div>
 
-            <div className="relative flex flex-col gap-6 rounded-[2.5rem] border border-white/10 bg-white/5 p-8 backdrop-blur-xl">
-              <div aria-hidden className="absolute -right-16 -top-16 h-44 w-44 rounded-full bg-cyan-400/20 blur-3xl" />
-              <div className="space-y-3">
-                <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/80">Stack créative Sept. 2025</p>
-                <p className="text-sm leading-relaxed text-slate-200/80">
-                  Sony Burano 8K · FX6 Duo · DJI Inspire 3 · Runway Gen-5 · Sora Color Suite · DaVinci Resolve Neural 19 · ElevenLabs Dubbing · Notion AI Ops.
-                </p>
-              </div>
-              <div className="space-y-3">
-                <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/80">Services phares</p>
-                <ul className="space-y-2 text-sm text-slate-200/70">
-                  {CATEGORIES.map((category) => (
-                    <li key={category.slug} className="flex items-center justify-between gap-4">
-                      <span>{category.label}</span>
-                      <Link to={`/services/${category.slug}`} className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-200">
-                        Voir
-                      </Link>
-                    </li>
-                  ))}
-                </ul>
-              </div>
+            <div className="space-y-5 rounded-[2.75rem] border border-white/10 bg-white/5 p-8 backdrop-blur-2xl">
+              <p className="text-xs uppercase tracking-[0.35em] text-white/60">
+                Pourquoi Studio VBG ?
+              </p>
+              <ul className="space-y-3 text-sm text-white/75">
+                <li>✅ Un seul interlocuteur du brief à la livraison</li>
+                <li>🎯 Pensé ROI : script orienté conversion & diffusion</li>
+                <li>⚡ Délais courts avec options express</li>
+                <li>📱 Social-first : déclinaisons verticales & sous-titres</li>
+              </ul>
+              <p className="text-[0.7rem] uppercase tracking-[0.3em] text-white/50">
+                Droits, révisions, livrables détaillés → FAQ budgétaire dans le <Link to="/blog" className="underline decoration-dotted decoration-white/50 underline-offset-4">Blog</Link>.
+              </p>
             </div>
           </div>
         </header>
 
-        {/* SERVICE SECTIONS */}
-        <div className="mt-20 space-y-16">
-          {services.map((service) => {
-            const packs = servicePacks[service.slug] ?? [];
-            return (
-              <section
-                key={service.slug}
-                id={`service-${service.slug}`}
-                className="rounded-[3rem] border border-white/10 bg-white/5 p-10 backdrop-blur-2xl"
-              >
-                <div className="flex flex-col gap-10 lg:grid lg:grid-cols-[1.1fr_0.9fr]">
-                  <div className="space-y-6">
-                    <div className="flex flex-wrap items-center gap-3 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-white/60">
-                      <span>{service.title}</span>
-                      <span className="opacity-50">•</span>
-                      <span>{service.timeline}</span>
-                    </div>
-                    <h2 className="text-3xl font-bold text-white sm:text-4xl">{service.hook}</h2>
-                    <p className="text-sm text-white/70">{service.promise}</p>
-                    <div className="space-y-4">
-                      <p className="text-xs font-semibold uppercase tracking-[0.3em] text-white/60">Essentiel du déroulement</p>
-                      <ol className="grid gap-3 text-sm text-white/70">
-                        {service.phases.slice(0, 5).map((phase, index) => (
-                          <li
-                            key={phase.title}
-                            className="rounded-[2rem] border border-white/10 bg-slate-950/60 p-4"
-                          >
-                            <p className="text-[0.6rem] font-semibold uppercase tracking-[0.35em] text-white/50">
-                              Étape 0{index + 1}
-                            </p>
-                            <p className="mt-2 text-sm text-white">{phase.title}</p>
-                            <p className="mt-1 text-sm text-white/70">{phase.description}</p>
-                            <p className="mt-2 text-xs text-sky-200/80">Upgrade IA : {phase.aiUpgrade}</p>
-                          </li>
-                        ))}
-                      </ol>
-                    </div>
-                  </div>
+        <section className="space-y-8">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div className="space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-[0.35em] text-white/60">
+                Panorama des services
+              </p>
+              <h2 className="text-3xl font-bold text-white">Choisissez le module adapté à votre objectif</h2>
+            </div>
+            <p className="max-w-xl text-sm text-white/65">
+              Chaque section ci-dessous se concentre sur un format précis : déroulement, process détaillé et packs clairs. Les fiches complètes restent accessibles pour approfondir.
+            </p>
+          </div>
 
-                  <div className="space-y-6">
-                    <div className="space-y-3">
-                      <p className="text-xs font-semibold uppercase tracking-[0.3em] text-white/60">Packs & livrables</p>
-                      <div className="grid gap-4">
-                        {packs.map((pack) => (
-                          <div key={pack.name} className="rounded-[2.5rem] border border-white/10 bg-slate-950/70 p-6">
-                            <div className="flex flex-wrap items-center justify-between gap-2 text-sm text-white/70">
-                              <span className="text-white">{pack.name}</span>
-                              <span>{pack.price}</span>
-                            </div>
-                            <p className="mt-2 text-sm text-white/60">{pack.description}</p>
-                            <ul className="mt-4 space-y-2 text-sm text-white/70">
-                              {pack.includes.map((item) => (
-                                <li key={item} className="flex items-start gap-2">
-                                  <span className="mt-1 h-1.5 w-1.5 rounded-full bg-sky-400/80" aria-hidden />
-                                  <span>{item}</span>
-                                </li>
-                              ))}
-                            </ul>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                    <div className="space-y-3 rounded-[2.5rem] border border-white/10 bg-slate-950/60 p-6 text-sm text-white/70">
-                      <p className="text-xs uppercase tracking-[0.3em] text-white/50">Livrables inclus</p>
-                      <ul className="space-y-1">
-                        {service.deliverables.map((deliverable) => (
-                          <li key={deliverable}>{deliverable}</li>
-                        ))}
-                      </ul>
-                      <p className="text-xs uppercase tracking-[0.35em] text-white/50">Preuve</p>
-                      <p className="text-sm text-white">{service.proof}</p>
-                      <Link
-                        to={`/contact?service=${service.slug}`}
-                        className="mt-4 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-sky-200"
-                      >
-                        Demander un devis détaillé
-                        <span aria-hidden>→</span>
-                      </Link>
-                    </div>
+          <div className="grid gap-6 lg:grid-cols-3">
+            {services.map((service) => (
+              <Link
+                key={`${service.slug}-card`}
+                to={`#${service.slug}`}
+                className="group relative overflow-hidden rounded-[2.5rem] border border-white/10 bg-slate-950/60 p-6 transition hover:border-sky-300/40"
+              >
+                <div className="absolute inset-0 translate-y-full bg-gradient-to-t from-sky-500/20 via-transparent to-transparent transition-transform duration-700 group-hover:translate-y-0" aria-hidden />
+                <div className="relative space-y-4">
+                  <p className="text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-white/60">{service.name}</p>
+                  <h3 className="text-xl font-semibold text-white">{service.title}</h3>
+                  <p className="text-sm text-white/70">{service.description}</p>
+                  <div className="flex flex-wrap gap-4 text-[0.65rem] uppercase tracking-[0.3em] text-white/50">
+                    <span>{service.startingPrice}</span>
+                    <span>{service.timeline}</span>
+                  </div>
+                  <span className="inline-flex items-center gap-2 text-[0.65rem] uppercase tracking-[0.35em] text-sky-200">
+                    Explorer le détail
+                    <span aria-hidden>→</span>
+                  </span>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </section>
+
+        {services.map((service) => (
+          <section
+            key={service.slug}
+            id={service.slug}
+            className="scroll-mt-32 space-y-12 rounded-[3rem] border border-white/10 bg-white/5 p-10 backdrop-blur-2xl"
+          >
+            <header className="grid gap-8 lg:grid-cols-[1.2fr_1fr] lg:items-center">
+              <div className="space-y-5">
+                <span className="inline-flex items-center gap-3 rounded-full border border-white/20 bg-white/10 px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-white/60">
+                  {service.name}
+                </span>
+                <div className="space-y-4">
+                  <h3 className="text-3xl font-semibold text-white">{service.title}</h3>
+                  <p className="text-base text-white/75">{service.subtitle}</p>
+                </div>
+                <div className="flex flex-wrap gap-6 text-sm text-white/70">
+                  <div>
+                    <p className="text-[0.6rem] uppercase tracking-[0.35em] text-white/55">À partir de</p>
+                    <p className="mt-2 text-xl font-semibold text-white">{service.startingPrice}</p>
+                  </div>
+                  <div>
+                    <p className="text-[0.6rem] uppercase tracking-[0.35em] text-white/55">Timeline</p>
+                    <p className="mt-2 text-xl font-semibold text-white">{service.timeline}</p>
                   </div>
                 </div>
-              </section>
-            );
-          })}
-        </div>
+                <div className="flex flex-wrap gap-3">
+                  {service.benefits.map((benefit) => (
+                    <span
+                      key={benefit}
+                      className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-4 py-2 text-[0.65rem] uppercase tracking-[0.3em] text-white/70"
+                    >
+                      {benefit}
+                    </span>
+                  ))}
+                </div>
+              </div>
 
-        <div className="mt-20 rounded-[3rem] border border-white/10 bg-slate-950/70 p-8 text-sm text-white/70">
-          <p className="text-xs uppercase tracking-[0.35em] text-white/50">FAQ budgétaire</p>
-          <p className="mt-3">
-            Pour toutes les questions liées aux droits musicaux, aux révisions, aux délais ou aux livrables, consultez la section « Conseils » du blog. Vous y trouverez les repères budgétaires détaillés et des modèles de checklists à télécharger.
-          </p>
-          <Link to="/blog" className="mt-4 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-sky-200">
-            Accéder à la FAQ
-            <span aria-hidden>→</span>
+              <aside className="rounded-[2.5rem] border border-white/10 bg-slate-950/70 p-6 text-sm text-white/75">
+                <p className="text-[0.6rem] uppercase tracking-[0.35em] text-white/55">Formats proposés</p>
+                <ul className="mt-4 space-y-3">
+                  {service.formats.map((format) => (
+                    <li key={format.title} className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                      <p className="text-sm font-semibold text-white">{format.title}</p>
+                      <p className="mt-1 text-sm text-white/70">{format.description}</p>
+                    </li>
+                  ))}
+                </ul>
+              </aside>
+            </header>
+
+            <div className="grid gap-10 lg:grid-cols-[1.2fr_1fr]">
+              <div className="space-y-8">
+                <div className="space-y-4">
+                  <h4 className="text-xl font-semibold text-white">Essentiel du déroulement</h4>
+                  <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                    {(
+                      [
+                        { label: "Préprod", steps: service.workflow.preprod },
+                        { label: "Prod", steps: service.workflow.production },
+                        { label: "Postprod", steps: service.workflow.postprod },
+                        { label: "Livrables", steps: service.workflow.delivery },
+                      ] as const
+                    ).map((block) => (
+                      <div key={block.label} className="rounded-[2rem] border border-white/10 bg-slate-950/70 p-5">
+                        <p className="text-[0.6rem] uppercase tracking-[0.35em] text-white/55">{block.label}</p>
+                        <ul className="mt-3 space-y-2 text-sm text-white/75">
+                          {block.steps.map((item) => (
+                            <li key={item} className="flex items-start gap-2">
+                              <span className="mt-1 h-1.5 w-1.5 rounded-full bg-sky-300" aria-hidden />
+                              <span>{item}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="space-y-4">
+                  <h4 className="text-xl font-semibold text-white">Processus détaillé</h4>
+                  <ol className="grid gap-4 sm:grid-cols-2">
+                    {service.process.map((phase, index) => (
+                      <li key={phase.title} className="rounded-[2rem] border border-white/10 bg-slate-950/70 p-6">
+                        <p className="text-[0.6rem] uppercase tracking-[0.35em] text-white/55">Étape 0{index + 1}</p>
+                        <p className="mt-3 text-lg font-semibold text-white">{phase.title}</p>
+                        <p className="mt-2 text-sm text-white/75">{phase.description}</p>
+                      </li>
+                    ))}
+                  </ol>
+                </div>
+              </div>
+
+              <aside className="space-y-6">
+                <div className="rounded-[2.5rem] border border-white/10 bg-white/5 p-6">
+                  <p className="text-[0.6rem] uppercase tracking-[0.35em] text-white/55">Livrables inclus</p>
+                  <ul className="mt-3 space-y-2 text-sm text-white/80">
+                    {service.deliverables.map((item) => (
+                      <li key={item} className="flex items-start gap-2">
+                        <span className="mt-1 h-1.5 w-1.5 rounded-full bg-fuchsia-300" aria-hidden />
+                        <span>{item}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+
+                {service.options?.length ? (
+                  <div className="rounded-[2.5rem] border border-white/10 bg-white/5 p-6">
+                    <p className="text-[0.6rem] uppercase tracking-[0.35em] text-white/55">Options</p>
+                    <ul className="mt-3 space-y-2 text-sm text-white/80">
+                      {service.options.map((option) => (
+                        <li key={option} className="flex items-start gap-2">
+                          <span className="mt-1 h-1.5 w-1.5 rounded-full bg-sky-300" aria-hidden />
+                          <span>{option}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
+
+                <div className="rounded-[2.5rem] border border-white/10 bg-slate-950/70 p-6 text-sm text-white/80">
+                  <p className="text-[0.6rem] uppercase tracking-[0.35em] text-white/55">Packs & tarifs</p>
+                  <div className="mt-3 grid gap-3">
+                    {service.pricing.map((pack) => (
+                      <div key={pack.name} className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                        <p className="text-xs font-semibold uppercase tracking-[0.35em] text-white/60">{pack.name}</p>
+                        <p className="mt-2 text-lg font-semibold text-white">{pack.price}</p>
+                        <p className="mt-1 text-sm text-white/70">{pack.description}</p>
+                      </div>
+                    ))}
+                  </div>
+                  <div className="mt-5 flex flex-wrap gap-3">
+                    <Link
+                      to={`/contact?service=${service.slug}`}
+                      className="inline-flex items-center gap-2 rounded-full border border-sky-300/40 bg-sky-500/20 px-5 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-white"
+                    >
+                      Demander un devis
+                    </Link>
+                    <Link
+                      to={`/services/${service.slug}`}
+                      className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-5 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-white/75 transition hover:bg-white/15 hover:text-white"
+                    >
+                      Voir la fiche détaillée
+                    </Link>
+                  </div>
+                </div>
+
+                <p className="text-xs uppercase tracking-[0.3em] text-white/55">
+                  Besoin de précisions sur droits musicaux, révisions ou délais ? Consultez la <Link to="/blog" className="underline decoration-dotted decoration-white/50 underline-offset-4">FAQ budgétaire</Link> du blog.
+                </p>
+              </aside>
+            </div>
+          </section>
+        ))}
+
+        <section className="space-y-6 rounded-[3rem] border border-white/10 bg-white/5 p-10 backdrop-blur-2xl">
+          <div className="space-y-4">
+            <h2 className="text-3xl font-bold text-white">Méthode Studio VBG</h2>
+            <p className="text-sm text-white/70">
+              Brief clair → Préparation simple → Tournage léger → Montage soigné → Livraison multi-formats. La même exigence s’applique à chaque service, avec des ajustements selon votre secteur.
+            </p>
+          </div>
+          <ol className="grid gap-4 lg:grid-cols-5">
+            {methodSteps.map((step, index) => (
+              <li key={step.title} className="rounded-[2.5rem] border border-white/10 bg-slate-950/70 p-6">
+                <p className="text-[0.6rem] uppercase tracking-[0.35em] text-white/55">Étape 0{index + 1}</p>
+                <p className="mt-3 text-lg font-semibold text-white">{step.title}</p>
+                <p className="mt-2 text-sm text-white/75">{step.description}</p>
+              </li>
+            ))}
+          </ol>
+        </section>
+
+        <section className="rounded-[3rem] border border-white/10 bg-gradient-to-br from-slate-900/80 via-slate-900/50 to-slate-900/80 p-10 text-sm text-white/75 backdrop-blur-2xl">
+          <div className="space-y-4">
+            <h2 className="text-3xl font-bold text-white">Prêts à cadrer votre projet ?</h2>
+            <p>
+              Brief express, budget indicatif et deadline suffisent pour recevoir un cadrage clair sous 24 h ouvrées. Formulaire + prise de rendez-vous disponibles sur la page contact.
+            </p>
+          </div>
+          <Link
+            to="/contact"
+            className="mt-6 inline-flex items-center gap-3 rounded-full border border-white/25 bg-white/10 px-6 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-white transition hover:bg-white/15"
+          >
+            Accéder au formulaire contact & devis
           </Link>
-        </div>
+        </section>
       </div>
     </div>
   );

--- a/src/pages/nav.config.ts
+++ b/src/pages/nav.config.ts
@@ -1,0 +1,1 @@
+export * from "@/components/header/nav.config";


### PR DESCRIPTION
## Summary
- expand site navigation to cover six service categories while moving portfolio links to the /portfolio routes
- rebuild the Services overview to present workflow, packs, and contact guidance without duplicate FAQ blocks
- enrich service detail pages with structured workflows, updated pricing packs, and pointers to the blog FAQ

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d72a6ee9748328a81289327068345a